### PR TITLE
Add EstimateSampleSizes to endpoint_classes.

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVBallots/BallotInterpretationDuplicatesBeforeOvervotes.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVBallots/BallotInterpretationDuplicatesBeforeOvervotes.java
@@ -1,0 +1,10 @@
+package us.freeandfair.corla.model.IRVBallots;
+
+public class BallotInterpretationDuplicatesBeforeOvervotes {
+
+    public static IRVChoices InterpretValidIntent(final IRVChoices b) {
+        IRVChoices i3 = b.ApplyRule3();
+        IRVChoices i1 = i3.ApplyRule1();
+        return i1.ApplyRule2();
+    }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVBallots/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVBallots/IRVChoices.java
@@ -1,0 +1,153 @@
+package us.freeandfair.corla.model.IRVBallots;
+
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/* A ballot is a set of (rank, candidate name) pairs. This data structure allows them to be
+ * invalid, that is, with repeated candidate names or repeated preferences.
+ */
+public class IRVChoices {
+    private List<Preference> choices;
+
+    public int getLength() {
+        return choices.size();
+    }
+
+    public IRVChoices(List<Preference> mutableChoices) {
+        mutableChoices.sort(Preference::compareTo);
+        choices = Collections.unmodifiableList(mutableChoices);
+    }
+
+
+    // Build a new ballot from the string of CandidateName(rank) strings in the colorado-rla database.
+    public IRVChoices(String sanitizedChoices) {
+        ArrayList<Preference> mutableChoices = new ArrayList<>();
+
+        String[] preferences = sanitizedChoices.trim().split(",");
+        if (preferences.length == 0) {
+            return;
+        }
+        for (String preference : preferences) {
+            String[] vote = preference.split("\\(");
+            String rank = vote[1].split("\\)")[0];
+            if (!StringUtils.isNumeric(rank)) {
+                throw new RuntimeException("Couldn't parse ballot");
+                //Invalid rank. Ballot is not usable. IF ballot is invalid, this safeguards us against number format exception
+            }
+            mutableChoices.add(new Preference(Integer.parseInt(rank), vote[0].trim()));
+        }
+
+        mutableChoices.sort(Preference::compareTo);
+        choices = Collections.unmodifiableList(mutableChoices);
+    }
+
+    /* Check whether the ballot is a valid list of preferences without repeats of candidate names or ranks and
+     * without skipped or invalid preferences.
+     */
+    public boolean IsValid() {
+
+        Set<String> candidateNamesSet = new HashSet<>();
+        // add to set returns false if the item is already present.
+        boolean allNamesDistinct = choices.stream().map(c -> candidateNamesSet.add(c.getCandidateName())).reduce(true, (b1,b2) -> b1 && b2);
+        if (!allNamesDistinct) {
+            return false;
+        }
+
+        // Test for a perfect integer sequence of length choices.size(), by filling in the i-th element when i is read.
+        boolean[] preferencesInOrder = new boolean[choices.size()];
+        for(Preference p : choices) {
+            // If this preference is out of bounds or already used, the pref list is invalid
+            if (p.getRank() < 1 || p.getRank() > choices.size() || preferencesInOrder[p.getRank()-1]) {
+                return false;
+            }
+            preferencesInOrder[p.getRank()-1] = true;
+        }
+
+        return true;
+    }
+
+    /* Applies Rule 26.7.1 from
+     * https://www.sos.state.co.us/pubs/rule_making/CurrentRules/8CCR1505-1/Rule26.pdf
+     * Returns new updated ballot.
+     */
+    public IRVChoices ApplyRule1() {
+
+        assert IsSorted(choices) : "Error: Trying to apply Rule 1 to unsorted preferences.";
+
+        List<Preference> mutableChoices = new ArrayList<Preference>(choices);
+        for (int i=0 ; i < mutableChoices.size()-1 ; i++) {
+            if ((mutableChoices.get(i)).compareTo(mutableChoices.get(i + 1)) == 0) {
+                // We found an overvote. Skip from this item.
+                mutableChoices.subList(i, mutableChoices.size()).clear();
+                break;
+            }
+        }
+
+        return new IRVChoices(mutableChoices);
+    }
+
+
+    /* Applies Rule 26.7.2 from
+     * https://www.sos.state.co.us/pubs/rule_making/CurrentRules/8CCR1505-1/Rule26.pdf
+     * Returns new updated ballot.
+     */
+    public IRVChoices ApplyRule2() {
+
+        assert IsSorted(choices) : "Error: Trying to apply Rule 2 to unsorted preferences.";
+
+
+        // If the first element is not rank 1, the ballot is effectively blank.
+        if(!choices.isEmpty() && choices.get(0).getRank() != 1) {
+            return new IRVChoices(new ArrayList<Preference>());
+        }
+
+        List<Preference> mutableChoices = new ArrayList<Preference>(choices);
+
+        for (int i=0 ; i < mutableChoices.size()-1 ; i++) {
+            if ((mutableChoices.get(i+1)).getRank() > mutableChoices.get(i).getRank() + 1) {
+                // We found a skipped rank. Skip from the _next_ item.
+                mutableChoices.subList(i+1, mutableChoices.size()).clear();
+                break;
+            }
+        }
+
+        return new IRVChoices(mutableChoices);
+    }
+
+    /* Applies Rule 26.7.3 from
+     * https://www.sos.state.co.us/pubs/rule_making/CurrentRules/8CCR1505-1/Rule26.pdf
+     * Returns new updated ballot.
+     */
+    public IRVChoices ApplyRule3() {
+
+        assert IsSorted(choices) : "Error: Trying to apply Rule 3 to unsorted preferences.";
+
+        HashSet<String> candidates = new HashSet<>();
+        List<Preference> mutableChoices = new ArrayList<Preference>();
+
+        for (Preference choice : choices) {
+            if (!candidates.contains(choice.getCandidateName())) {
+                // This candidate hasn't been mentioned before. Add it to both the vote and the set of mentioned candidates.
+                mutableChoices.add(choice);
+                candidates.add(choice.getCandidateName());
+            }
+        }
+
+        return new IRVChoices(mutableChoices);
+    }
+
+    public String toString() {
+        return choices.stream().map(Preference::toString).collect(Collectors.joining(","));
+    }
+
+    private boolean IsSorted(List<Preference> choices) {
+        for (int i=0 ; i < choices.size()-1 ; i++) {
+            if ((choices.get(i)).compareTo(choices.get(i + 1)) > 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVBallots/Preference.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVBallots/Preference.java
@@ -1,0 +1,31 @@
+package us.freeandfair.corla.model.IRVBallots;
+
+
+public class Preference implements Comparable<Preference> {
+
+    private final Integer rank;
+    private final String candidateName;
+
+    public int getRank() {
+        return rank;
+    }
+
+    public String getCandidateName() {
+        return candidateName;
+    }
+    public Preference(Integer r, String name) {
+        rank = r;
+        candidateName = name;
+    }
+
+    // We only care about whether the rank is lower than the other rank,
+    // not the name of the candidate.
+    @Override
+    public int compareTo(Preference preference) {
+        return this.rank.compareTo(preference.rank);
+    }
+
+    public String toString() {
+        return candidateName+"("+rank+")";
+    }
+}

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/model/IRVBallotInterpretationTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/model/IRVBallotInterpretationTest.java
@@ -1,0 +1,354 @@
+package us.freeandfair.corla.model;
+
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+import static org.junit.Assert.*;
+
+import us.freeandfair.corla.model.IRVBallots.BallotInterpretationDuplicatesBeforeOvervotes;
+import us.freeandfair.corla.model.IRVBallots.IRVChoices;
+
+public class IRVBallotInterpretationTest {
+    private IRVBallotInterpretationTest() {}
+    @BeforeTest()
+    public void setUp() {
+    }
+
+    @AfterTest()
+    public void tearDown() {
+    }
+
+    /*
+     * Using the DuplicatesBeforeOvervotes function and testing against the
+     * specific examples in the Guide.
+     */
+    @Test
+    void Example1OvervotesNoValidRankings() {
+        IRVChoices b = new IRVChoices("Candidate A(1),Candidate B(1),Candidate C(1),Candidate C(2),Candidate B(3)");
+        String expectedInterpretation = "";
+
+        IRVChoices interpretation = BallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(b);
+
+        assertEquals(interpretation.toString(), expectedInterpretation);
+
+    }
+
+    @Test
+    void Example2OvervoteWithValidRankings() {
+        IRVChoices b = new IRVChoices("Candidate B(1),Candidate A(2),Candidate C(2),Candidate C(3)");
+        String expectedInterpretation = "Candidate B(1)";
+
+        IRVChoices interpretation = BallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(b);
+
+        assertEquals(interpretation.toString(), expectedInterpretation);
+
+    }
+
+    @Test
+    void Example1SkippedRankings() {
+        IRVChoices b = new IRVChoices("Candidate A(1),Candidate B(3)");
+        String expectedInterpretation = "Candidate A(1)";
+
+        IRVChoices interpretation = BallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(b);
+
+        assertEquals(interpretation.toString(), expectedInterpretation);
+
+    }
+
+    @Test
+    void Example1DuplicateRankings() {
+        IRVChoices b = new IRVChoices("Candidate A(1),Candidate A(2),Candidate B(3)");
+        String expectedInterpretation = "Candidate A(1)";
+
+        IRVChoices interpretation = BallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(b);
+
+        assertEquals(interpretation.toString(), expectedInterpretation);
+
+    }
+
+    @Test
+    void Example1DuplicatesAndOvervotes() {
+        IRVChoices b = new IRVChoices("Candidate B(1),Candidate A(2),Candidate C(2),Candidate C(3)");
+        String expectedInterpretation = "Candidate B(1)";
+
+        IRVChoices interpretation = BallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(b);
+
+        assertEquals(interpretation.toString(), expectedInterpretation);
+
+    }
+
+    @Test
+    void Example2DuplicatesAndOvervotes() {
+        IRVChoices b = new IRVChoices("Candidate B(1),Candidate A(2),Candidate B(2),Candidate C(3)");
+        String expectedInterpretation ="Candidate B(1),Candidate A(2),Candidate C(3)";
+
+        IRVChoices interpretation = BallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(b);
+
+        assertEquals(interpretation.toString(), expectedInterpretation);
+
+    }
+
+    /*
+     * Other general validity tests for ballot interpretation,
+     * including applying single rules and checking the validity
+     * of the output.
+     */
+    @Test
+    void testValidBallots() {
+        IRVChoices b = new IRVChoices("Alice(1)");
+        assertTrue(b.IsValid());
+        assert b.IsValid();
+
+        b = new IRVChoices("Alice(1),Bob(2)");
+        assert b.IsValid();
+
+        b = new IRVChoices("Alice(1),Chuan(3),Bob(2)");
+        assert b.IsValid();
+
+        b = new IRVChoices("Diego(4),Alice(1),Chuan(3),Bob(2)");
+        assert b.IsValid();
+    }
+
+    @Test
+    void testInvalidBallot() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(1)");
+        assert !b.IsValid();
+
+        b = new IRVChoices("Alice(1),Alice(2)");
+        assert !b.IsValid();
+
+        b = new IRVChoices("Alice(1),Bob(1)");
+        assert !b.IsValid();
+
+        b = new IRVChoices("Alice(1),Bob(3)");
+        assert !b.IsValid();
+
+        b = new IRVChoices("Alice(2),Bob(2)");
+        assert !b.IsValid();
+
+        b = new IRVChoices("Alice(2),Bob(3)");
+        assert !b.IsValid();
+    }
+
+    @Test
+    void applyRule1Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2)");
+        IRVChoices i = b.ApplyRule1();
+        assert i.getLength() == 2;
+    }
+
+    @Test
+    void applyRule1Test2() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(1)");
+        IRVChoices i = b.ApplyRule1();
+        assert i.getLength() == 0;
+    }
+
+    @Test
+    void applyRule1Test3() {
+        IRVChoices b = new IRVChoices("Alice(2),Alice(1)");
+        IRVChoices i = b.ApplyRule1();
+        assert i.getLength() == 2;
+    }
+
+    @Test
+    void applyRule1Test4() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(2)");
+        IRVChoices i = b.ApplyRule1();
+        assert i.getLength() == 1;
+    }
+
+    @Test
+    void applyRule1Test5() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(2),Diego(3)");
+        IRVChoices i = b.ApplyRule1();
+        assert i.getLength() == 1;
+    }
+
+    @Test
+    void applyRule1Test6() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(3),Diego(3)");
+        IRVChoices i = b.ApplyRule1();
+        assert i.getLength() == 2;
+    }
+
+    @Test
+    void applyRule2Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 2;
+    }
+
+    @Test
+    void applyRule2Test2() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(1)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 2;
+    }
+
+    @Test
+    void applyRule2Test3() {
+        IRVChoices b = new IRVChoices("Alice(2),Alice(1)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 2;
+    }
+
+    @Test
+    void applyRule2Test4() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(3)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 3;
+    }
+
+    @Test
+    void applyRule2Test5() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(3)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 1;
+    }
+
+    @Test
+    void applyRule2Test6() {
+        IRVChoices b = new IRVChoices("Bob(2),Chuan(3)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 0;
+    }
+
+    @Test
+    void applyRule2Test7() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(4)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 2;
+    }
+
+    @Test
+    void applyRule2Test8() {
+        IRVChoices b = new IRVChoices("Alice(3),Bob(2),Chuan(4)");
+        IRVChoices i2 = b.ApplyRule2();
+        assert i2.getLength() == 0;
+    }
+
+    @Test
+    void applyRule1AndRule2Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(2),Diego(4)");
+        IRVChoices i = b.ApplyRule1();
+        IRVChoices i2 = i.ApplyRule2();
+        assert i2.getLength() == 1;
+    }
+
+    @Test
+    void applyRule1AndRule2Test2() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(2),Diego(4)");
+        IRVChoices i2 = b.ApplyRule2();
+        IRVChoices i1 = i2.ApplyRule1();
+        assert i1.getLength() == 1;
+    }
+
+    @Test
+    void applyRule3Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 2;
+    }
+
+    @Test
+    void applyRule3Test2() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(1)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 1;
+    }
+
+    @Test
+    void applyRule3Test3() {
+        IRVChoices b = new IRVChoices("Alice(2),Alice(1)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 1;
+    }
+
+    @Test
+    void applyRule3Test4() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(3)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 3;
+    }
+
+    @Test
+    void applyRule3Test5() {
+        IRVChoices b = new IRVChoices("Alice(1),Bob(3)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 2;
+    }
+
+    @Test
+    void applyRule3Test6() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(2)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 2;
+    }
+
+    @Test
+    void applyRule3Test7() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(2),Chuan(4),Bob(3)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 3;
+    }
+
+    @Test
+    void applyRule3Test8() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Alice(4)");
+        IRVChoices i3 = b.ApplyRule3();
+        assert i3.getLength() == 1;
+    }
+    @Test
+    void applyRule3AndRule2Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(2)");
+        IRVChoices i3 = b.ApplyRule3();
+        IRVChoices i2 = i3.ApplyRule2();
+        assert i2.getLength() == 2;
+        assert i2.IsValid();
+    }
+
+    @Test
+    void applyRule3AndRule2Test3() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(3)");
+        IRVChoices i3 = b.ApplyRule3();
+        IRVChoices i2 = i3.ApplyRule2();
+        assert i2.getLength() == 1;
+        assert i2.IsValid();
+    }
+
+    @Test
+    void applyRule2AndRule3Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(2)");
+        IRVChoices i2 = b.ApplyRule2();
+        IRVChoices i3 = i2.ApplyRule3();
+        assert i3.getLength() == 2;
+        assert i3.IsValid();
+    }
+
+    @Test
+    void applyRule2AndRule3Test3() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(3)");
+        IRVChoices i2 = b.ApplyRule2();
+        IRVChoices i3 = i2.ApplyRule3();
+        assert i3.getLength() == 2;
+        assert !i3.IsValid();
+    }
+    @Test
+    void applyRule1AndRule3Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(2)");
+        IRVChoices i1 = b.ApplyRule1();
+        IRVChoices i3 = i1.ApplyRule3();
+        assert i3.getLength() == 1;
+        assert i3.IsValid();
+    }
+
+    @Test
+    void applyRule3AndRule1Test1() {
+        IRVChoices b = new IRVChoices("Alice(1),Alice(2),Bob(2)");
+        IRVChoices i3 = b.ApplyRule3();
+        IRVChoices i1 = i3.ApplyRule1();
+        assert i1.getLength() == 2;
+        assert i1.IsValid();
+    }
+}


### PR DESCRIPTION
Classes and utilities for dealing with invalid IRV ballots, e.g. those with skipped or repeated preferences. This class implements the CO interpretation rules.