### PR TITLE
Irv interpretation on input and audit

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
@@ -575,6 +575,8 @@ public class DominionCVRExportParser {
           // Throw an exception if it can't be parsed, _not_ if it's merely an invalid IRV preference list.
           if (co.description().equalsIgnoreCase(ContestType.IRV.toString())) {
             try {
+              // Currently deciding to log both the raw and (later, same as plurality) the interpreted IRV votes.
+              LOGGER.debug("Raw IRV vote: "+votes);
               contest_info.add(new CVRContestInfo(co, null, null,
                                                                  IRVVoteToValidInterpretationAsSortedList(votes)));
             } catch (IRVParsingException e) {

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/csv/DominionCVRExportParser.java
@@ -570,10 +570,13 @@ public class DominionCVRExportParser {
 
       // if this contest was on the ballot, add it to the votes
       if (present) {
-          // If this is an IRV contest, rewrite the vote to remove parenthesized ranks.
+          // If this is an IRV contest, the vote to remove parenthesized ranks and compute the valid interpretation.
+          // Then store the valid interpretation as an orded list of candidate names without explicit ranks.
+          // Throw an exception if it can't be parsed, _not_ if it's merely an invalid IRV preference list.
           if (co.description().equalsIgnoreCase(ContestType.IRV.toString())) {
             try {
-              contest_info.add(new CVRContestInfo(co, null, null, parseValidIRVVote(votes)));
+              contest_info.add(new CVRContestInfo(co, null, null,
+                                                                 IRVVoteToValidInterpretationAsSortedList(votes)));
             } catch (IRVParsingException e) {
               throw new IllegalArgumentException(e);
             }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
@@ -91,7 +91,7 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
   }
 
   /** build new acvr **/
-  public CastVoteRecord buildNewAcvr(final SubmittedAuditCVR submission,
+  public static CastVoteRecord buildNewAcvr(final SubmittedAuditCVR submission,
                                      final CastVoteRecord cvr,
                                      final CountyDashboard cdb) throws IRVParsingException {
     final CastVoteRecord s = submission.auditCVR();
@@ -113,7 +113,7 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
   /* Iterates through the uploaded Cast Vote Record and, for each IRV contest, changes the choices
    * to one that replaces the raw IRV vote with its valid interpretation.
    */
-  private List<CVRContestInfo> interpretIRVChoicesInACVR(List<CVRContestInfo> oldCVRChoices) throws IRVParsingException {
+  private static List<CVRContestInfo> interpretIRVChoicesInACVR(List<CVRContestInfo> oldCVRChoices) throws IRVParsingException {
     List<CVRContestInfo> newCVRChoices = new ArrayList<>();
 
     for ( CVRContestInfo ci : oldCVRChoices ) {
@@ -127,7 +127,7 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
       }
     }
 
-    return null;
+    return newCVRChoices;
   }
   /**
    * {@inheritDoc}

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ACVRUpload.java
@@ -12,8 +12,11 @@
 package us.freeandfair.corla.endpoint;
 
 import static us.freeandfair.corla.asm.ASMEvent.AuditBoardDashboardEvent.*;
+import static us.freeandfair.corla.util.IRVVoteParsing.IRVVoteToValidInterpretationAsSortedList;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 import javax.persistence.PersistenceException;
 
@@ -28,10 +31,13 @@ import us.freeandfair.corla.Main;
 import us.freeandfair.corla.asm.ASMEvent;
 import us.freeandfair.corla.controller.ComparisonAuditController;
 import us.freeandfair.corla.json.SubmittedAuditCVR;
+import us.freeandfair.corla.model.CVRContestInfo;
 import us.freeandfair.corla.model.CastVoteRecord;
 import us.freeandfair.corla.model.CastVoteRecord.RecordType;
+import us.freeandfair.corla.model.ContestType;
 import us.freeandfair.corla.model.CountyDashboard;
 import us.freeandfair.corla.persistence.Persistence;
+import us.freeandfair.corla.util.IRVParsingException;
 
 /**
  * The "audit CVR upload" endpoint.
@@ -87,14 +93,15 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
   /** build new acvr **/
   public CastVoteRecord buildNewAcvr(final SubmittedAuditCVR submission,
                                      final CastVoteRecord cvr,
-                                     final CountyDashboard cdb) {
+                                     final CountyDashboard cdb) throws IRVParsingException {
     final CastVoteRecord s = submission.auditCVR();
+    final List<CVRContestInfo> contestInfo =  interpretIRVChoicesInACVR(s.contestInfo());
     final CastVoteRecord newAcvr =
       new CastVoteRecord(RecordType.AUDITOR_ENTERED,
                          Instant.now(),
                          s.countyID(), s.cvrNumber(), null, s.scannerID(),
                          s.batchID(), s.recordID(), s.imprintedID(),
-                         s.ballotType(), s.contestInfo());
+                         s.ballotType(), contestInfo);
     newAcvr.setAuditBoardIndex(submission.getAuditBoardIndex());
     newAcvr.setCvrId(submission.cvrID());
     newAcvr.setRoundNumber(cdb.currentRound().number());
@@ -103,6 +110,25 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
     return newAcvr;
   }
 
+  /* Iterates through the uploaded Cast Vote Record and, for each IRV contest, changes the choices
+   * to one that replaces the raw IRV vote with its valid interpretation.
+   */
+  private List<CVRContestInfo> interpretIRVChoicesInACVR(List<CVRContestInfo> oldCVRChoices) throws IRVParsingException {
+    List<CVRContestInfo> newCVRChoices = new ArrayList<>();
+
+    for ( CVRContestInfo ci : oldCVRChoices ) {
+      // For IRV, make new IRV choices as an ordered list without parenthesized ranks.
+      if( ci.contest().description().equalsIgnoreCase(ContestType.IRV.toString()) ) {
+        List<String> newIRVChoices =IRVVoteToValidInterpretationAsSortedList(ci.choices());
+        newCVRChoices.add( new CVRContestInfo(ci.contest(), ci.comment(), ci.consensus(), newIRVChoices));
+      } else {
+        // for plurality, just keep it as it is
+        newCVRChoices.add(ci);
+      }
+    }
+
+    return null;
+  }
   /**
    * {@inheritDoc}
    */
@@ -119,11 +145,6 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
         badDataContents(the_response, "empty audit CVR upload");
       } else {
         // FIXME extract-fn: handleACVR
-        // NOTE: Ballot interpretation has to happen here.
-        // Assume that submission.my_audit_cvr (which is a CastVoteRecord) has
-        // its choices recorded as "Alice(1)", "Bob(2)", etc. Later, when the
-        // audit CVR is created (forming newAcvr), its choices will be represented
-        // without attached rankings.
         final CountyDashboard cdb =
             Persistence.getByID(Main.authentication().authenticatedCounty(the_request).id(),
                                 CountyDashboard.class);
@@ -202,6 +223,9 @@ public class ACVRUpload extends AbstractAuditBoardDashboardEndpoint {
     } catch (final PersistenceException e) {
       LOGGER.error("could not save audit CVR");
       serverError(the_response, "Unable to save audit CVR");
+    } catch (IRVParsingException e ) {
+      LOGGER.error("could not parse audit CVR");
+      serverError(the_response, "Unable to parse audit CVR");
     }
     return my_endpoint_result.get();
   }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/IRVChoices.java
@@ -1,6 +1,7 @@
 package us.freeandfair.corla.model;
 
 import org.apache.commons.lang3.StringUtils;
+import us.freeandfair.corla.util.IRVParsingException;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -25,8 +26,6 @@ public class IRVChoices {
 
 
     // Build a new ballot from the string of CandidateName(rank) strings in the colorado-rla database.
-    // FIXME probably almost everywhere that calls this now, will instead want to be called on an ordered list
-    // of choices.
     public IRVChoices(String sanitizedChoices) {
         ArrayList<IRVPreference> mutableChoices = new ArrayList<>();
 
@@ -152,13 +151,13 @@ public class IRVChoices {
      * and ending with the lowest.
      * Throws an exception if called on an invalid vote.
      */
-    public List<String> AsSortedList() {
+    public List<String> AsSortedList() throws IRVParsingException {
         // Neither of these calls should ever be made.
         if ( !IsValid() ) {
-            throw new RuntimeException("Attempt to call AsSortedList on invalid vote: "+choices);
+            throw new IRVParsingException("Attempt to call AsSortedList on invalid vote: "+choices);
         }
         if (! IsSorted(choices)) {
-            throw new RuntimeException("Attempt to call AsSortedList on unsorted choices.");
+            throw new IRVParsingException("Attempt to call AsSortedList on unsorted choices.");
         }
 
         return choices.stream().map(IRVPreference::getCandidateName).collect(Collectors.toUnmodifiableList());

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/util/IRVVoteParsing.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/util/IRVVoteParsing.java
@@ -1,6 +1,7 @@
 package us.freeandfair.corla.util;
 
 import us.freeandfair.corla.model.Choice;
+import us.freeandfair.corla.model.IRVBallotInterpretationDuplicatesBeforeOvervotes;
 import us.freeandfair.corla.model.IRVChoices;
 import us.freeandfair.corla.model.IRVPreference;
 
@@ -23,6 +24,21 @@ public class IRVVoteParsing {
        }
 
        return new IRVChoices(choices);
+    }
+
+    /* Takes a list of candidate 'names' which are expected to be real candidate names with an IRV rank
+     * in parentheses, applies the valid interpretation rules, and
+     * returns a list of names only, sorted by preference order (highest preference first).
+     * Exception is thrown only if it can't be parsed, not if the preference list isn't valid.
+     */
+    public static List<String> IRVVoteToValidInterpretationAsSortedList(final List<String> votes) throws IRVParsingException {
+        IRVChoices choices = parseIRVVote(votes);
+
+        IRVChoices validInterpretation =
+                IRVBallotInterpretationDuplicatesBeforeOvervotes.InterpretValidIntent(choices);
+
+        return validInterpretation.AsSortedList();
+
     }
 
     /* Takes a list of candidate 'names' which are expected to be real candidate names with an IRV rank
@@ -161,10 +177,11 @@ public class IRVVoteParsing {
 
         // Look for digits in parentheses at the end of the string.
         String regexp ="\\((\\d+\\))$";
+        String trimmed = nameAndPref.trim();
 
         try {
-            String vote = nameAndPref.split(regexp)[0];
-            String rank1 = nameAndPref.replace(vote, "");
+            String vote = trimmed.split(regexp)[0];
+            String rank1 = trimmed.replace(vote, "");
                     String rank2 = rank1.trim().split("[\\(\\)]")[1];
 
             return new IRVPreference(Integer.parseInt(rank2), vote.trim());

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/endpoint/ACVRUploadTest.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/endpoint/ACVRUploadTest.java
@@ -1,0 +1,176 @@
+package us.freeandfair.corla.endpoint;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import org.testng.annotations.*;
+
+import us.freeandfair.corla.Main;
+import us.freeandfair.corla.json.SubmittedAuditCVR;
+import us.freeandfair.corla.model.*;
+import us.freeandfair.corla.persistence.Persistence;
+import us.freeandfair.corla.query.ContestQueries;
+import us.freeandfair.corla.query.CountyQueries;
+import us.freeandfair.corla.query.Setup;
+import us.freeandfair.corla.util.IRVParsingException;
+
+import java.io.FileReader;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static us.freeandfair.corla.endpoint.ACVRUpload.buildNewAcvr;
+
+
+@Test(groups = {"integration"})
+public class ACVRUploadTest {
+
+  private ACVRUploadTest() {}
+
+
+  @BeforeMethod
+  public void setUp() {
+    Setup.setProperties();
+    Persistence.beginTransaction();
+
+    // Create DoSDashboard with some audit information.
+    DoSDashboard dosdb = Persistence.getByID(DoSDashboard.ID, DoSDashboard.class);
+    dosdb.updateAuditInfo(new AuditInfo("general", Instant.now(), Instant.now(),
+            "12856782643571354365", BigDecimal.valueOf(0.05)));
+    Persistence.persist(dosdb);
+
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    try {
+      Persistence.rollbackTransaction();
+    } catch (Exception e) {
+      System.out.println(e.getMessage());
+    }
+  }
+
+  /**
+   * Create a Plurality contest for the given county, contest name, and with the given
+   * distribution of votes.
+   *
+   * @param county            County to which the contest belongs (name).
+   * @param contest           Name of the contest.
+   * @param candidate_votes   Map between candidate name and their vote total.
+   * @param total             Total number of CVRs with the contest on it.
+   */
+  private void createIRVContest(String county, String contest, Map<String,Integer> candidate_votes, int total){
+    County cty = CountyQueries.fromString(county);
+
+    // To do: need to add ballot manifest data.
+    BallotManifestInfo bmi = new BallotManifestInfo(cty.id(), 1, "1",
+            total, "Bin 1", 1L, (long) total);
+
+    Persistence.persist(bmi);
+
+    Set<String> candidates = candidate_votes.keySet();
+    List<Choice> choices = candidates.stream().map(c -> { return new Choice(c,
+            "", false, false);}).collect(Collectors.toList());
+    Contest c1 = new Contest(contest, cty, "IRV", choices, 10,
+            1, 0);
+
+    Persistence.persist(c1);
+    CountyContestResult ctr = new CountyContestResult(cty, c1);
+
+    ctr.updateResults();
+    Persistence.persist(ctr);
+  }
+
+  /**
+   * Creates and persists an example Plurality election for the Boulder county called
+   * Board of Parks.
+   */
+  private void createBoulderChessBoard(){
+    createIRVContest("Boulder", "BoulderChessBoard",
+            Map.of("Alice", 20, "Bob", 10, "Chuan", 100, "Diego", 40,
+            "Alice(1)", 3, "Alice(2)", 4, "Bob(2)", 3,
+            "Chuan(3)", 3, "Chuan(4)",0, "Diego(4)", 3), 186);
+  }
+
+  /**
+   * Creates and persists an example Plurality election for the Broomfield county called
+   * Board of Parks.
+   */
+  private void createBroomfieldChessBoard(){
+    createIRVContest("Broomfield", "BroomfieldChessBoard",
+            Map.of("Alice", 20, "Bob", 10, "Chuan", 100, "Diego", 40,
+            "Alice(1)", 3, "Alice(2)", 4, "Bob(2)", 3,
+            "Chuan(3)", 3, "Chuan(4)",0, "Diego(4)", 3), 186);
+  }
+
+  /**
+   * Test of estimate sample sizes endpoint logic for
+   * Plurality contests (one county specific contest in two counties).
+   */
+  @Test()
+  public void testIRVACVRInterpretation() throws IRVParsingException {
+      createBoulderChessBoard();
+      createBroomfieldChessBoard();
+
+      Contest boulderTestContest = ContestQueries.matching("BoulderChessBoard").get(0);
+      Contest broomfieldTestContest = ContestQueries.matching("BroomfieldChessBoard").get(0);
+
+      List <CVRContestInfo> contestInfoList = List.of(
+              new CVRContestInfo(boulderTestContest, "", CVRContestInfo.ConsensusValue.YES,
+                      List.of("Alice(1)", "Bob(2)", "Chuan(3)", "Diego(4)")),
+              new CVRContestInfo(broomfieldTestContest, "", CVRContestInfo.ConsensusValue.YES,
+                      List.of("Alice(1)", "Alice(2)", "Bob(2)", "Chuan(4)", "Diego(4)"))
+              );
+
+      CastVoteRecord testCVR1 = new CastVoteRecord(CastVoteRecord.RecordType.UPLOADED,
+              Instant.MIN, 1L, 1, 1, 1, "Batch 1",
+              1, "1-1-1", "Audit", contestInfoList );
+
+      SubmittedAuditCVR testSubmittedCVR1 = new SubmittedAuditCVR(1L, testCVR1);
+
+      County testCounty = new County("c1", 1L);
+      CountyDashboard cdb = new CountyDashboard(testCounty);
+      cdb.startRound(2, 2, 0 , List.of(1L), List.of(1L));
+
+      CastVoteRecord newACVR  = buildNewAcvr( testSubmittedCVR1, testCVR1, cdb);
+      assertEquals(newACVR.contestInfo().get(0).choices(), List.of("Alice", "Bob", "Chuan", "Diego"));
+      assertEquals(newACVR.contestInfo().get(1).choices(), List.of("Alice", "Bob"));
+  }
+
+  /**
+   * Creates a cast vote record in a given Plurality contest containing a vote
+   * for the given candidate (name).
+   *
+   * @param name      Name of candidate being voted for in this CVR.
+   * @param co        Contest
+   * @param position  CVR position (used when creating CVR objects)
+   * @return A CastVoteRecord object containing a vote for the given candidate (name).
+   */
+  private CastVoteRecord createVoteFor(final String name, final Contest co, Integer position){
+    // Create CVRContestInfo
+    List<String> votes = new ArrayList<>();
+    votes.add(name);
+
+    CVRContestInfo ci = new CVRContestInfo(co, null,null, votes);
+    List<CVRContestInfo> contest_info = new ArrayList<>();
+    contest_info.add(ci);
+
+    CastVoteRecord cvr = new CastVoteRecord(CastVoteRecord.RecordType.UPLOADED,
+            null,
+            1L,
+            position,
+            1,
+            1,
+            "1",
+            1,
+            "1",
+            "a",
+            contest_info);
+    Persistence.persist(cvr);
+    return cvr;
+  }
+}

--- a/test/Tiny-IRV-Tests/ThreeCandidatesTenInvalidVotes.csv
+++ b/test/Tiny-IRV-Tests/ThreeCandidatesTenInvalidVotes.csv
@@ -1,0 +1,14 @@
+Tiny IRV Example Contest 1,5.10.11.24,,,,,,,,,,,,,,
+,,,,,,,"TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)"
+,,,,,,,Alice(1),Bob(1),Chuan(1),Alice(2),Bob(2),Chuan(2),Alice(3),Bob(3),Chuan(3)
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,PrecinctPortion,BallotType,,,,,,,,,
+1,1,1,1,1-1-1,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,0,0,0,1
+2,1,1,2,1-1-2,Precinct 1,Ballot 1 - Type 1,1,0,0,0,1,0,1,0,1
+3,1,1,3,1-1-3,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,0,1,0,1
+4,1,1,4,1-1-4,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,0,0,1,1
+5,1,1,5,1-1-5,Precinct 1,Ballot 1 - Type 1,1,0,0,0,1,1,0,1,0
+6,1,1,6,1-1-6,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,1,0,1,0
+7,1,1,7,1-1-7,Precinct 1,Ballot 1 - Type 1,1,0,0,0,0,0,0,0,1
+8,1,1,8,1-1-8,Precinct 1,Ballot 1 - Type 1,1,0,0,1,0,0,0,1,0
+9,1,1,9,1-1-9,Precinct 1,Ballot 1 - Type 1,1,0,1,1,0,0,0,1,0
+10,1,1,10,1-1-10,Precinct 1,Ballot 1 - Type 1,0,1,1,1,0,0,0,1,0

--- a/test/Tiny-IRV-Tests/ThreeCandidatesTenInvalidVotes.csv.sha256sum
+++ b/test/Tiny-IRV-Tests/ThreeCandidatesTenInvalidVotes.csv.sha256sum
@@ -1,0 +1,1 @@
+c86f791278dde7a0d035c2c97b4f3f3e282013b50f79feeb17da5e9fa40e4697  ThreeCandidatesTenInvalidVotes.csv

--- a/test/Tiny-IRV-Tests/ThreeCandidatesTenInvalidVotes_withInterpretations.csv
+++ b/test/Tiny-IRV-Tests/ThreeCandidatesTenInvalidVotes_withInterpretations.csv
@@ -1,0 +1,14 @@
+Tiny IRV Example Contest 1,5.10.11.24,,,,,,,,,,,,,,,
+NOTE: Don’t try to upload this to colorado-rla – it’s just here so humans can check the correct valid interpretation,,,,,,,"TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)","TinyInvalidExample1 (Number of positions=1, Number of ranks=3)",
+,,,,,,,Alice(1),Bob(1),Chuan(1),Alice(2),Bob(2),Chuan(2),Alice(3),Bob(3),Chuan(3),Valid Interpretation
+CvrNumber,TabulatorNum,BatchId,RecordId,ImprintedId,PrecinctPortion,BallotType,,,,,,,,,,
+1,1,1,1,1-1-1,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,0,0,0,1,"A, B, C"
+2,1,1,2,1-1-2,Precinct 1,Ballot 1 - Type 1,1,0,0,0,1,0,1,0,1,"A, B, C"
+3,1,1,3,1-1-3,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,0,1,0,1,"A, B, C"
+4,1,1,4,1-1-4,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,0,0,1,1,"A,B,C"
+5,1,1,5,1-1-5,Precinct 1,Ballot 1 - Type 1,1,0,0,0,1,1,0,1,0,A
+6,1,1,6,1-1-6,Precinct 1,Ballot 1 - Type 1,1,0,0,1,1,1,0,1,0,A
+7,1,1,7,1-1-7,Precinct 1,Ballot 1 - Type 1,1,0,0,0,0,0,0,0,1,A
+8,1,1,8,1-1-8,Precinct 1,Ballot 1 - Type 1,1,0,0,1,0,0,0,1,0,A
+9,1,1,9,1-1-9,Precinct 1,Ballot 1 - Type 1,1,0,1,1,0,0,0,1,0,Blank
+10,1,1,10,1-1-10,Precinct 1,Ballot 1 - Type 1,0,1,1,1,0,0,0,1,0,Blank


### PR DESCRIPTION
This now does IRV interpretation on both initial CSV input and audit. The initial CVR input is reasonably easy to test. However, the audit step is still completely untested, because we really need some edits to the client. The intended idea is that in the audit step, the client will upload a possibly-invalid set of choices of the form "Alice(1), Bob(2)" etc. These will then be read in via the ACVRUpload endpoint. They'll be passed through valid IRV interpretation, translated into an ordered sequence of valid choices (without the parenthesized ranks) and stored.

There are two main remaining challenges:
1. the initial client upload: we need to edit the .tx in the client to allow the audit board to enter possibly-invalid sets of choices of the right form,
2. the pre-processing storage. It's possible the initial upload will be rejected by the server because its explicitly-parenthesized choices don't match the (non-ranked) allowed choices for the contest. I'm not sure whether this will be a problem or not - it depends whether the call to         Main.GSON.fromJson(the_request.body(), SubmittedAuditCVR.class); in ACVRUpload does the usual validity checks on the choices.