### PR TITLE
New est ss page

### DIFF
--- a/client/src/action/dos/estimateSampleSizes.ts
+++ b/client/src/action/dos/estimateSampleSizes.ts
@@ -1,0 +1,7 @@
+import { endpoint } from 'corla/config';
+
+export default () => {
+    const url = `${endpoint('estimate-sample-sizes')}`;
+
+    window.location.replace(url);
+};

--- a/client/src/component/DOS/DefineAudit/EstimateSampleSizesPage.tsx
+++ b/client/src/component/DOS/DefineAudit/EstimateSampleSizesPage.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+
+import { Breadcrumb, Button, Card, Intent } from '@blueprintjs/core';
+
+import estimateSampleSizes from 'corla/action/dos/estimateSampleSizes';
+import DOSLayout from 'corla/component/DOSLayout';
+
+const Breadcrumbs = () => (
+    <ul className='pt-breadcrumbs mb-default'>
+        <li><Breadcrumb href='/sos' text='SoS' />></li>
+        <li><Breadcrumb href='/sos/audit' text='Audit Admin' /></li>
+        <li><Breadcrumb className='pt-breadcrumb-current' text='Estimate Sample Sizes' /></li>
+    </ul>
+);
+
+interface EstimateSampleSizesPageProps {
+    forward: OnClick;
+}
+
+
+class EstimateSampleSizesPage extends React.Component<EstimateSampleSizesPageProps> {
+    public constructor(props: EstimateSampleSizesPageProps) {
+        super(props);
+    }
+
+    public render() {
+        const {
+            forward,
+        } = this.props;
+
+
+        const main =
+            <div>
+                <Breadcrumbs/>
+                <h2>Estimate Sample Sizes for all Contests</h2>
+                <p>
+                    Clicking on the estimate button will produce a CSV file containing
+                    sample sizes for all contests in the database, which will be
+                    automatically downloaded.
+                </p>
+                <div className='control-buttons mt-default'>
+                    <Button onClick={estimateSampleSizes}
+                            className='pt-button pt-intent-primary'>
+                        Estimate
+                    </Button>
+                </div>
+
+                <div className='control-buttons mt-default'>
+                    <Button onClick={forward}
+                            className='pt-button pt-intent-primary'>
+                        Next
+                    </Button>
+                </div>
+            </div>;
+
+        return <DOSLayout main={ main } />;
+    }
+
+}
+
+export default EstimateSampleSizesPage;

--- a/client/src/component/DOS/DefineAudit/EstimateSampleSizesPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/EstimateSampleSizesPageContainer.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react';
+
+import { Redirect } from 'react-router-dom';
+
+import { History } from 'history';
+
+import EstimateSampleSizesPage from './EstimateSampleSizesPage';
+
+import withDOSState from 'corla/component/withDOSState';
+import withSync from 'corla/component/withSync';
+
+interface ContainerProps {
+    dosState: DOS.AppState;
+    history: History;
+}
+
+class EstimateSampleSizesPageContainer extends React.Component<ContainerProps> {
+
+    public render() {
+        const {
+            dosState,
+            history,
+        } = this.props;
+
+        if (!dosState) {
+            return <div />;
+        }
+
+        if (!dosState.asm) {
+            return <div />;
+        }
+
+        if (dosState.asm === 'DOS_AUDIT_ONGOING') {
+            return <Redirect to='/sos' />;
+        }
+
+        const props = {
+            dosState,
+            forward: () => history.push('/sos/audit/select-contests'),
+        };
+
+        return <EstimateSampleSizesPage { ...props } />;
+    }
+}
+
+const mapStateToProps = (dosState: DOS.AppState) => {
+    if (!dosState) { return {}; }
+
+    return {
+        dosState,
+    };
+};
+
+export default withSync(
+    withDOSState(EstimateSampleSizesPageContainer),
+    'DOS_ESTIMATE_SAMPLE_SIZES_SYNC',
+    mapStateToProps,
+);

--- a/client/src/component/DOS/DefineAudit/GenerateAssertionsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/GenerateAssertionsPageContainer.tsx
@@ -39,7 +39,7 @@ class GenerateAssertionsPageContainer extends React.Component<ContainerProps> {
 
         const props = {
             dosState,
-            forward: () => history.push('/sos/audit/select-contests'),
+            forward: () => history.push('/sos/audit/estimate-sample-sizes'),
             readyToGenerate,
         };
 

--- a/client/src/component/RootContainer.tsx
+++ b/client/src/component/RootContainer.tsx
@@ -16,6 +16,8 @@ import CountyDashboardPageContainer from './County/Dashboard/PageContainer';
 
 import LoginContainer from './Login/Container';
 
+
+import DOSDefineAuditEstimateSampleSizesPageContainer from './DOS/DefineAudit/EstimateSampleSizesPageContainer';
 import DOSDefineAuditGenerateAssertionsPageContainer from './DOS/DefineAudit/GenerateAssertionsPageContainer';
 import DOSDefineAuditReviewPageContainer from './DOS/DefineAudit/ReviewPageContainer';
 import DOSDefineAuditSeedPageContainer from './DOS/DefineAudit/SeedPageContainer';
@@ -76,6 +78,9 @@ export class RootContainer extends React.Component<RootContainerProps> {
                         <LoginRoute exact
                                     path='/sos/audit/generate-assertions'
                                     page={ DOSDefineAuditGenerateAssertionsPageContainer } />
+                        <LoginRoute exact
+                                    path='/sos/audit/estimate-sample-sizes'
+                                    page={ DOSDefineAuditEstimateSampleSizesPageContainer } />
                         <LoginRoute exact
                                     path='/sos/audit/select-contests'
                                     page={ DOSDefineAuditSelectContestsPageContainer } />


### PR DESCRIPTION
Added a new page in the Define Audit process for sample size estimation. Currently, clicking the Estimate button will initiate the process of sample size estimation  and a CSV file will be automatically downloaded at the end. This is far from perfect as there is no error handling or feedback provided to the user in this prototype version of the feature (other than a download).