### PR TITLE
Move riskMeasurement() into ComparisonAudit.java.

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/model/ComparisonAudit.java
@@ -501,6 +501,27 @@ public class ComparisonAudit implements PersistentEntity {
   }
 
   /**
+   * Risk limit achieved according to math.Audit.
+   * This has a fallback to 1.0 (max risk) when ``nothing is known''.
+   **/
+  public BigDecimal riskMeasurement() {
+    if (my_audited_sample_count > 0
+        && diluted_margin.compareTo(BigDecimal.ZERO) > 0) {
+      final BigDecimal result =  Audit.pValueApproximation(my_audited_sample_count,
+          diluted_margin,
+          my_gamma,
+          my_one_vote_under_count,
+          my_two_vote_under_count,
+          my_one_vote_over_count,
+          my_two_vote_over_count);
+      return result.setScale(3, BigDecimal.ROUND_HALF_UP);
+    } else {
+      // full risk (100%) when nothing is known
+      return BigDecimal.ONE;
+    }
+  }
+
+  /**
    * A scaling factor for the estimate, from 1 (when no samples have
    * been audited) upward.41
    The scaling factor grows as the ratio of

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/report/ReportRows.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/report/ReportRows.java
@@ -330,25 +330,7 @@ public class ReportRows {
     }
   }
 
-  /** risk limit achieved according to math.Audit **/
-  public static BigDecimal riskMeasurement(final ComparisonAudit ca) {
-    if (ca.getAuditedSampleCount() > 0
-        && ca.getDilutedMargin().compareTo(BigDecimal.ZERO) > 0) {
-      final BigDecimal result =  Audit.pValueApproximation(ca.getAuditedSampleCount(),
-                                                           ca.getDilutedMargin(),
-                                                           ca.getGamma(),
-                                                           ca.discrepancyCount(-1),
-                                                           ca.discrepancyCount(-2),
-                                                           ca.discrepancyCount(1),
-                                                           ca.discrepancyCount(2));
-      return result.setScale(3, BigDecimal.ROUND_HALF_UP);
-    } else {
-      // full risk (100%) when nothing is known
-      return BigDecimal.ONE;
-    }
-  }
-
-  /** compare risk sought vs measured **/
+   /** compare risk sought vs measured **/
   public static boolean riskLimitMet(final BigDecimal sought, final BigDecimal measured) {
     return sought.compareTo(measured) > 0;
   }
@@ -383,7 +365,7 @@ public class ReportRows {
     for (final ComparisonAudit ca: ComparisonAuditQueries.sortedList()) {
       final Row row = SummaryReport.newRow();
 
-      final BigDecimal riskMsmnt = riskMeasurement(ca);
+      final BigDecimal riskMsmnt = ca.riskMeasurement();
 
       // general info
       row.put("Contest", ca.contestResult().getContestName());


### PR DESCRIPTION
This shifts the riskMeasurement() function from ReportRows.java to ComparisonAudit.java. The actual function is identical, but relies now on private fields of ComparisonAudit rather than getters.