### PR TITLE
90 irv ballot sanity checking

### DIFF
--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/ContestType.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/ContestType.java
@@ -1,0 +1,41 @@
+/*
+Democracy Developers IRV extensions to colorado-rla.
+
+@copyright 2024 Colorado Department of State
+
+These IRV extensions are designed to connect to a running instance of the raire 
+service (https://github.com/DemocracyDevelopers/raire-service), in order to 
+generate assertions that can be audited using colorado-rla.
+
+The colorado-rla IRV extensions are free software: you can redistribute it and/or modify it under the terms
+of the GNU Affero General Public License as published by the Free Software Foundation, either
+version 3 of the License, or (at your option) any later version.
+
+The colorado-rla IRV extensions are distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with
+raire-service. If not, see <https://www.gnu.org/licenses/>.
+*/
+
+package au.org.democracydevelopers.corla.model;
+
+/**
+ * The possible types of contests that can be audited, including plurality and IRV.
+ * Used for setting up the correct kinds of audits and doing the correct validity tests on choices.
+ */
+public enum ContestType {
+  /**
+   * Single- and multi-winner plurality elections. Voters select their favourite candidates(s), and
+   * the winner is the one with the most votes.
+   */
+  PLURALITY,
+
+  /**
+   * Instant-runoff voting (IRV). Voters select candidates with ranks (preferences). The winner is
+   * determined by a process of eliminating the candidate with the lowest tally and redistributing
+   * their votes according to the next preference, until a candidate has a majority.
+   */
+  IRV
+}

--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -108,7 +108,7 @@ public class IRVChoices {
     }
 
     // This constructor should be applied only to sorted choices.
-    if (ChoicesAreUnsorted()) {
+    if (choicesAreUnsorted()) {
       final String msg = String.format("%s called on unsorted choices: %s.", prefix, choices);
       LOGGER.error(msg);
       throw new RuntimeException(msg);

--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -92,7 +92,7 @@ public class IRVChoices {
    * choices (overvotes, skipped preferences, repeated candidate names).
    * @param sortedChoices a list of IRVPreferences, which need not be valid - repeats or skipped
    *                      preferences are allowed.
-   * @param firstDropped  the first index of the sorted choices to omit. If this is 1, we get an
+   * @param firstDropped  the first index of the sorted choices to omit. If this is 0, we get an
    *                      empty choices list.
    */
   private IRVChoices(List<IRVPreference> sortedChoices, int firstDropped) {
@@ -305,7 +305,7 @@ public class IRVChoices {
     // If the choices are blank, return blank. If the first element is not rank 1, the vote is
     // effectively blank.
     if (choices.isEmpty() || choices.get(0).rank != 1) {
-      return new IRVChoices(new ArrayList<IRVPreference>(),1);
+      return new IRVChoices(new ArrayList<>(),1);
     }
 
     List<IRVPreference> nonSkipChoices = new ArrayList<>(choices);

--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -131,7 +131,9 @@ public class IRVChoices {
    *   constructor is the only one we need.
    */
   public IRVChoices(String sanitizedChoices) throws IRVParsingException {
-    this(Arrays.asList(sanitizedChoices.trim().split(",")));
+    // Filtering for non-blanks is needed because split will add a blank if the input list is empty.
+    this((Arrays.stream(sanitizedChoices.trim().split(","))
+        .filter(s -> !s.isBlank())).collect(Collectors.toList()));
   }
 
   /**

--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -92,13 +92,20 @@ public class IRVChoices {
    * choices (overvotes, skipped preferences, repeated candidate names).
    * @param sortedChoices a list of IRVPreferences, which need not be valid - repeats or skipped
    *                      preferences are allowed.
+   * @param firstDropped  the first index of the sorted choices to omit. If this is 1, we get an
+   *                      empty choices list.
    */
   private IRVChoices(List<IRVPreference> sortedChoices, int firstDropped) {
     final String prefix = "[IRVChoices constructor]";
     LOGGER.debug(String.format("%s interpreting IRV Preferences %s", prefix, sortedChoices));
 
-    sortedChoices.subList(firstDropped, sortedChoices.size()).clear();
-    choices = Collections.unmodifiableList(sortedChoices);
+    if(firstDropped < sortedChoices.size()) {
+      // If firstDropped is inside the list, return the sublist (firstDropped is excluded)
+      choices = Collections.unmodifiableList(sortedChoices.subList(0, firstDropped));
+    } else {
+      // If firstDropped is off the end of the list, just return the whole list.
+      choices = Collections.unmodifiableList(sortedChoices);
+    }
 
     // This constructor should be applied only to sorted choices.
     if (ChoicesAreUnsorted()) {
@@ -135,8 +142,7 @@ public class IRVChoices {
    * stores in an unmodifiable list.
    *
    * @param rawChoices the IRV preferences as a list of strings, which need not be a valid IRV
-   *                   vote -
-   *                repeats or skipped preferences are allowed.
+   *                   vote - repeats or skipped preferences are allowed.
    * @throws IRVParsingException if one of the comma-separated substrings cannot be parsed as a
    *                             name(rank). This could happen for example if called on a
    *                             plurality vote.
@@ -303,7 +309,7 @@ public class IRVChoices {
     // If the choices are blank, return blank. If the first element is not rank 1, the vote is
     // effectively blank.
     if (choices.isEmpty() || choices.get(0).rank != 1) {
-      return new IRVChoices(new ArrayList<IRVPreference>(),0);
+      return new IRVChoices(new ArrayList<IRVPreference>(),1);
     }
 
     List<IRVPreference> nonSkipChoices = new ArrayList<>(choices);

--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -305,7 +305,7 @@ public class IRVChoices {
     // If the choices are blank, return blank. If the first element is not rank 1, the vote is
     // effectively blank.
     if (choices.isEmpty() || choices.get(0).rank != 1) {
-      return new IRVChoices(new ArrayList<>(),1);
+      return new IRVChoices(new ArrayList<>(),0);
     }
 
     List<IRVPreference> nonSkipChoices = new ArrayList<>(choices);

--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -121,7 +121,7 @@ public class IRVChoices {
 
   /**
    * Constructor - takes IRV preferences as a list of strings of the kind stored in the corla
-   * database, * of the form ["name1(p1)","name2(p2)", ...]
+   * database, of the form ["name1(p1)","name2(p2)", ...]
    * Parses each individual preference into an IRVPreference to make a list of IRVPreferences, and
    * then calls the other constructor, which sorts the list by rank (most to least preferred), then
    * stores in an unmodifiable list.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
@@ -220,7 +220,7 @@ public final class CVRContestInfoJsonAdapter
       // different from the valid interpreted list (which omits everything after skipped or repeated
       // prefernces).
       if (currentContest.description().equalsIgnoreCase(ContestType.IRV.toString())) {
-        IRVChoices parsedChoices = new IRVChoices(choices.toArray(String[]::new));
+        IRVChoices parsedChoices = new IRVChoices(choices);
         choicesForSanityChecking = parsedChoices.getCandidateNames();
         interpretedChoices = parsedChoices.GetValidIntentAsOrderedList();
         // For plurality, just do the sanity check directly on the choices.

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
@@ -222,7 +222,7 @@ public final class CVRContestInfoJsonAdapter
       if (currentContest.description().equalsIgnoreCase(ContestType.IRV.toString())) {
         IRVChoices parsedChoices = new IRVChoices(choices);
         choicesForSanityChecking = parsedChoices.getCandidateNames();
-        interpretedChoices = parsedChoices.GetValidIntentAsOrderedList();
+        interpretedChoices = parsedChoices.getValidIntentAsOrderedList();
         // For plurality, just do the sanity check directly on the choices.
       } else {
         choicesForSanityChecking = choices;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
@@ -188,9 +188,13 @@ public final class CVRContestInfoJsonAdapter
     }
     the_reader.endObject();
     
-    // check the sanity of the contest
+    // check the sanity of these choices for this contest. This means checking whether they can be
+    // parsed properly at all and, if so, whether the choices (candidate names or yes/no options)
+    // are the ones expected for this contest. For plurality, we expect plain choices that exactly
+    // match the valid choices; for IRV we expect something of the form "name(rank)" where "name"
+    // is a valid choice.
     final Contest currentContest = Persistence.getByID(contest_id, Contest.class);
-    Contest contest; // This is only used to check for null.
+    Contest contest;
 
     // For IRV contests, first check whether the choices can be parsed as a list of IRV
     // preferences. Duplicates, overvotes and skipped ranks are OK, but strings that can't be

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/json/CVRContestInfoJsonAdapter.java
@@ -149,7 +149,7 @@ public final class CVRContestInfoJsonAdapter
   @Override
   public CVRContestInfo read(final JsonReader the_reader) 
       throws IOException {
-    String preface = "[read]";
+    final String prefix = "[read]";
     boolean error = false;
     List<String> choices = null;
     long contest_id = -1;
@@ -218,7 +218,7 @@ public final class CVRContestInfoJsonAdapter
     try {
       // For IRV, the choices for sanity checking (which includes all mentioned candidates) are
       // different from the valid interpreted list (which omits everything after skipped or repeated
-      // prefernces).
+      // preferences).
       if (currentContest.description().equalsIgnoreCase(ContestType.IRV.toString())) {
         IRVChoices parsedChoices = new IRVChoices(choices);
         choicesForSanityChecking = parsedChoices.getCandidateNames();
@@ -232,7 +232,9 @@ public final class CVRContestInfoJsonAdapter
       Contest contest = contestSanityCheck(contest_id, choicesForSanityChecking);
 
       if (error || contest == null) {
-        throw new JsonSyntaxException("invalid data detected in CVR contest info");
+        final String msg = "invalid data detected in CVR contest info";
+        LOGGER.error(String.format("%s %s", prefix, msg));
+        throw new JsonSyntaxException(msg);
       }
 
       // TODO In the prototype, this function returns a CVRContestInfo with the raw choices
@@ -242,8 +244,9 @@ public final class CVRContestInfoJsonAdapter
       return new CVRContestInfo(contest, comment, consensus, interpretedChoices);
 
     } catch (IRVParsingException e) {
-      LOGGER.error(String.format("%s %s", preface, e.getMessage()));
-      throw new IOException("uploaded IRV vote could not be parsed");
+      final String msg = "uploaded IRV vote could not be parsed.";
+      LOGGER.error(String.format("%s %s", prefix, msg+" "+e.getMessage()));
+      throw new IOException(msg+" "+e.getMessage());
     }
   }
 }

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
@@ -315,7 +315,7 @@ public class IRVChoicesTests {
   }
 
   /**
-   * Test rule 2 - removing skipped rankings.
+   * Test rule 26.7.2 - removing skipped rankings.
    * First rank skipped - remove all.
    * @throws IRVParsingException never
    */
@@ -324,6 +324,19 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeSkipsTest4");
 
     IRVChoices b = new IRVChoices("Alice(3),Bob(2),Chuan(4)");
+    assertEquals(0, b.getValidIntentAsOrderedList().size());
+  }
+
+  /**
+   * Test rule 26.7.2 - removing skipped rankings.
+   * First rank is not 1 - remove all.
+   * @throws IRVParsingException never
+   */
+  @Test
+  public void removeSkipsTest5() throws IRVParsingException {
+    testUtils.log(LOGGER,"removeSkipsTest4");
+
+    IRVChoices b = new IRVChoices("Alice(3)");
     assertEquals(0, b.getValidIntentAsOrderedList().size());
   }
 

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
@@ -272,7 +272,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeOvervotesTest4");
 
     IRVChoices b = new IRVChoices("Alice(1),Bob(1)");
-    assertEqualListsOfStrings(List.of(), b.GetValidIntentAsOrderedList());
+    CollectionUtils.isEqualCollection(List.of(), b.getValidIntentAsOrderedList());
   }
 
   /**

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
@@ -262,6 +262,19 @@ public class IRVChoicesTests {
   }
 
   /**
+   * Test rule 26.7.1 - removing overvotes (repeated preferences).
+   * Removes repeated 1st preference, leaving nothing.
+   * @throws IRVParsingException never
+   */
+  @Test
+  public void removeOvervotesTest5() throws IRVParsingException {
+    testUtils.log(LOGGER,"removeOvervotesTest4");
+
+    IRVChoices b = new IRVChoices("Alice(1),Bob(1)");
+    assertEqualListsOfStrings(List.of(), b.GetValidIntentAsOrderedList());
+  }
+
+  /**
    * Test rule 26.7.2 - removing skipped rankings.
    * Removes all but the first preference.
    * @throws IRVParsingException never

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
@@ -135,9 +135,19 @@ public class IRVChoicesTests {
   }
 
   /**
+   * A blank vote is valid.
+   */
+  @Test
+  public void blankVoteIsValid() throws IRVParsingException {
+
+    IRVChoices b = new IRVChoices("");
+    assertTrue(b.isValid());
+    assertEquals(0, b.getValidIntentAsOrderedList().size());
+  }
+
+  /**
    * Other general validity tests for ballot interpretation,
-   * including applying single rules and checking the validity
-   * of the output.
+   * including a blank vote.
    * Valid choices.
    * @throws IRVParsingException never
    */


### PR DESCRIPTION
This expands the sanity checking so that IRV-style choices (e.g. Alice(2)) will be accepted (if and only if Alice is a valid choice in the contest). 

Obviously this needs a lot of careful testing, which is not currently in this PR. I'm going to pick up the csv parsing card next (which depends on this card) and then test them both together. It's a little hard to test this one on its own.