### PR TITLE
162 reaudit step not working

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -232,13 +232,14 @@ public final class ComparisonAuditController {
                                 final String comment) {
 
     LOGGER.info("[reaudit] cvr: " + cvr.toString());
-    final CVRAuditInfo cai =
-      Persistence.getByID(cvr.id(), CVRAuditInfo.class);
-    final CastVoteRecord oldAcvr = cai.acvr();
-    if (null == oldAcvr) {
+
+    // VT: If this cvr has not been audited before, I believe cai will be null.
+    final CVRAuditInfo cai = Persistence.getByID(cvr.id(), CVRAuditInfo.class);
+    if (cai == null || cai.acvr() == null) {
       LOGGER.error("can't reaudit a cvr that hasn't been audited");
       return false;
     }
+    final CastVoteRecord oldAcvr = cai.acvr();
 
     final Integer former_count = unaudit(cdb, cai);
     LOGGER.debug("[reaudit] former_count: " + former_count.toString());

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/controller/ComparisonAuditController.java
@@ -233,7 +233,7 @@ public final class ComparisonAuditController {
 
     LOGGER.info("[reaudit] cvr: " + cvr.toString());
 
-    // VT: If this cvr has not been audited before, I believe cai will be null.
+    // DemocracyDevelopers: If this cvr has not been audited before, cai will be null.
     final CVRAuditInfo cai = Persistence.getByID(cvr.id(), CVRAuditInfo.class);
     if (cai == null || cai.acvr() == null) {
       LOGGER.error("can't reaudit a cvr that hasn't been audited");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -579,6 +579,7 @@ public final class CastVoteRecordQueries {
     try {
       // Make sure not to return null, which causes errors later. 0L is the correct return value if
       // there are no prior revisions in the database.
+      // Some documentation says that getSingleResult() never returns null, but it definitely does.
       final Long result = (Long) q.getSingleResult();
       return result == null ? 0L : result;
     } catch (final PersistenceException e) {
@@ -586,7 +587,7 @@ public final class CastVoteRecordQueries {
       // TODO: Technically this should probably be an error code?
       // TODO: Otherwise there's no way to discern this from a CVR with no revisions?
       // VT: Agree. Since 0L is used for "valid; no prior revisions", suggest using a different value
-      // here or throwing an exception.
+      // here (-1?) or throwing an exception.
       return 0L;
     }
 

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/CastVoteRecordQueries.java
@@ -577,11 +577,16 @@ public final class CastVoteRecordQueries {
     q.setString("imprintedId", cvr.imprintedID());
 
     try {
-      return (Long) q.getSingleResult();
+      // Make sure not to return null, which causes errors later. 0L is the correct return value if
+      // there are no prior revisions in the database.
+      final Long result = (Long) q.getSingleResult();
+      return result == null ? 0L : result;
     } catch (final PersistenceException e) {
       // the DB had a problem!
       // TODO: Technically this should probably be an error code?
       // TODO: Otherwise there's no way to discern this from a CVR with no revisions?
+      // VT: Agree. Since 0L is used for "valid; no prior revisions", suggest using a different value
+      // here or throwing an exception.
       return 0L;
     }
 

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/endpoint/ACVRUploadTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/endpoint/ACVRUploadTests.java
@@ -306,6 +306,39 @@ public class ACVRUploadTests extends TestClassWithAuth {
       "}";
 
   /**
+   * 8. Reaudit of valid IRV vote, for CVR ID 240509; imprinted ID 1-1-1.
+   */
+  private static final String validIRVReauditAsJson = "{" +
+      "  \"cvr_id\": 240509," +
+      "  \"audit_cvr\": {" +
+      "    \"record_type\": \"AUDITOR_ENTERED\"," +
+      "    \"county_id\": 1," +
+      "    \"cvr_number\": 1," +
+      "    \"sequence_number\": 1," +
+      "    \"scanner_id\": 1," +
+      "    \"batch_id\": \"1\"," +
+      "    \"record_id\": 1," +
+      "    \"imprinted_id\": \"1-1-1\"," +
+      "    \"uri\": \"acvr:1:1-1-1\"," +
+      "    \"ballot_type\": \"Ballot 1 - Type 1\"," +
+      "    \"contest_info\": [" +
+      "      {" +
+      "        \"contest\": 240503," +
+      "        \"comment\": \"A comment\"," +
+      "        \"consensus\": \"YES\"," +
+      "        \"choices\": [" +
+      "          \"Alice(1)\"," +
+      "          \"Chuan(2)\"" +
+      "        ]" +
+      "      }" +
+      "    ]" +
+      "  }," +
+      "  \"reaudit\": true," +
+      "  \"comment\": \"\"," +
+      "  \"auditBoardIndex\": -1" +
+      "}";
+
+  /**
    * Database init.
    */
   @BeforeClass
@@ -338,8 +371,9 @@ public class ACVRUploadTests extends TestClassWithAuth {
    * 3. a blank IRV vote,
    * 4. a vote with non-IRV choices ("Alice" instead of "Alice(1)"),
    * 5. a vote with invalid choices (names not in the list of choices for the contest),
-   * 6. a vote that doesn't properly correspond to the IDs it should have, and
-   * 7. an unparseable vote (typos in json data).
+   * 6. a vote that doesn't properly correspond to the IDs it should have,
+   * 7. an unparseable vote (typos in json data), and
+   * 8. a reaudit.
    * We check that it is accepted and that the right records for CVR and CVRContestInfo are
    * stored in the database.
    */
@@ -399,6 +433,10 @@ public class ACVRUploadTests extends TestClassWithAuth {
       // Seventh test: upload a vote that has typos preventing json deserialization. This should
       // cause an error.
       testErrorResponse(240515L, IRVJsonDeserializationFail, malformedACVRMsg);
+
+      // Eighth test: upload a reaudit ballot.
+      testSuccessResponse(240509L, "1-1-1", validIRVReauditAsJson,
+          List.of("Alice","Chuan"), 3);
     }
   }
 

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/endpoint/ACVRUploadTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/endpoint/ACVRUploadTests.java
@@ -456,19 +456,19 @@ public class ACVRUploadTests extends TestClassWithAuth {
       //  Expected error messages for malformed upload cvrs.
       String malformedACVRMsg = "malformed audit CVR upload";
 
-      testErrorResponse(240512L, pluralityIRVAsJson, malformedACVRMsg);
+      testErrorResponseAndNoMatchingCvr(240512L, pluralityIRVAsJson, malformedACVRMsg);
 
       // Fifth test: upload a vote with IRV choices that are not among the valid candidates. This
       // should cause an error.
-      testErrorResponse(240513L, wrongCandidateNamesIRVAsJson, malformedACVRMsg);
+      testErrorResponseAndNoMatchingCvr(240513L, wrongCandidateNamesIRVAsJson, malformedACVRMsg);
 
       // Sixth test: upload a vote with IDs that do not correspond properly to the expected CVR.
       // This should cause an error.
-      testErrorResponse(240514L, IRVWithInconsistentIDsAsJson, malformedACVRMsg);
+      testErrorResponseAndNoMatchingCvr(240514L, IRVWithInconsistentIDsAsJson, malformedACVRMsg);
 
       // Seventh test: upload a vote that has typos preventing json deserialization. This should
       // cause an error.
-      testErrorResponse(240515L, IRVJsonDeserializationFail, malformedACVRMsg);
+      testErrorResponseAndNoMatchingCvr(240515L, IRVJsonDeserializationFail, malformedACVRMsg);
 
       // Eighth test: upload a reaudit ballot.
       // Check that the new data successfully replaces the prior upload.
@@ -484,7 +484,7 @@ public class ACVRUploadTests extends TestClassWithAuth {
       testPreviousAreReaudited(240509L, "1-1-1", List.of("Alice","Chuan"), 2, 2);
 
       // Tenth test: try to "re-"audit something that has not previously been successfully audited. Should throw an error.
-      testErrorResponse(240515L, IRVReauditNoPriorUpload, "");
+      testErrorResponseAndNoMatchingCvr(240515L, IRVReauditNoPriorUpload, "CVR has not previously been audited");
     }
   }
 
@@ -585,7 +585,7 @@ public class ACVRUploadTests extends TestClassWithAuth {
    * @param CvrAsJson     The upload cvr, as a json string.
    * @param expectedError The expected error message.
    */
-  private void testErrorResponse(final long CvrId, final String CvrAsJson, final String expectedError) {
+  private void testErrorResponseAndNoMatchingCvr(final long CvrId, final String CvrAsJson, final String expectedError) {
     final Request request = new SparkRequestStub(CvrAsJson, new HashSet<>());
     String errorBody = "";
 


### PR DESCRIPTION
This fixes two bugs in the reaudit phase, both of which caused nullpointer exceptions. It also adds some tests for proper functioning of various IRV reaudit attempts.