### PR TITLE
Disable tied IRV contests on select contests page

### DIFF
--- a/client/src/component/DOS/DefineAudit/SelectContestsForm.tsx
+++ b/client/src/component/DOS/DefineAudit/SelectContestsForm.tsx
@@ -234,7 +234,7 @@ class SelectContestsForm extends React.Component<FormProps, FormState> {
             const props = d.props;
             const { contest } = props;
 
-            const auditable = isAuditable(contest.id);
+            const auditable = isAuditable(contest);
 
             if (auditable) {
                 return <ContestRow { ...props } />;

--- a/client/src/component/DOS/DefineAudit/SelectContestsForm.tsx
+++ b/client/src/component/DOS/DefineAudit/SelectContestsForm.tsx
@@ -50,7 +50,12 @@ const TiedContestRow = (props: RowProps) => {
                           disabled={ true } />
             </td>
             <td>
-                Contest cannot be audited due to a reported tie.
+                Contest cannot be audited due to a reported tie
+                {
+                    (contest.description === 'IRV')
+                        ? ' or assertion generation error.'
+                        : '.'
+                }
             </td>
         </tr>
     );

--- a/client/src/component/DOS/DefineAudit/SelectContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/SelectContestsPageContainer.tsx
@@ -8,8 +8,8 @@ import withPoll from 'corla/component/withPoll';
 
 import SelectContestsPage from './SelectContestsPage';
 
-import selectContestsForAudit from 'corla/action/dos/selectContestsForAudit';
 import resetAudit from 'corla/action/dos/resetAudit';
+import selectContestsForAudit from 'corla/action/dos/selectContestsForAudit';
 
 interface ContainerProps {
     auditedContests: DOS.AuditedContests;
@@ -40,8 +40,8 @@ class SelectContestsPageContainer extends React.Component<ContainerProps> {
         if (dosState.asm === 'DOS_AUDIT_ONGOING') {
             return <Redirect to='/sos' />;
         }
-        const previousPage = async() => {
-			      await resetAudit();
+        const previousPage = async () => {
+            await resetAudit();
             history.push('/sos/audit');
         };
         const props = {
@@ -58,10 +58,20 @@ class SelectContestsPageContainer extends React.Component<ContainerProps> {
 }
 
 function mapStateToProps(dosState: DOS.AppState) {
-    const isAuditable = (contestId: number): boolean => {
+    const isAuditable = (contest: Contest): boolean => {
         if (!dosState.auditTypes) { return false; }
 
-        const t = dosState.auditTypes[contestId];
+        if (contest.description === 'IRV') {
+            const assertionSummary = dosState.generateAssertionsSummaries.find(
+                element => element.contestName === contest.name);
+
+            // Tied IRV contests are not auditable
+            if (assertionSummary && assertionSummary.error === 'TIED_WINNERS') {
+                return false;
+            }
+        }
+
+        const t = dosState.auditTypes[contest.id];
 
         return t !== 'HAND_COUNT' && t !== 'NOT_AUDITABLE';
     };

--- a/client/src/component/DOS/DefineAudit/SelectContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/SelectContestsPageContainer.tsx
@@ -65,8 +65,8 @@ function mapStateToProps(dosState: DOS.AppState) {
             const assertionSummary = dosState.generateAssertionsSummaries.find(
                 element => element.contestName === contest.name);
 
-            // Tied IRV contests are not auditable
-            if (assertionSummary && assertionSummary.error === 'TIED_WINNERS') {
+            // Tied IRV contests or contests with failed assertion generations are not auditable
+            if (assertionSummary && assertionSummary.error.length > 0) {
                 return false;
             }
         }


### PR DESCRIPTION
Tested with ThreeCandidatesTenVotes_TiedIRV test data (thanks for making that!).  There was existing logic to handle tied plurality votes so I added the IRV logic there.  