### PR TITLE
use Thread.currentThread().getContextClassLoader() for more robust resource loading

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/Main.java
@@ -236,8 +236,10 @@ public final class Main {
    */
   public static Properties defaultProperties() {
     final Properties properties = new Properties();
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
     try {
-      properties.load(ClassLoader.getSystemResourceAsStream(DEFAULT_PROPERTIES));
+      properties.load(classLoader.getResourceAsStream(DEFAULT_PROPERTIES));
     } catch (final IOException e) {
       throw new IllegalStateException
       ("Error loading default properties file, aborting.", e);
@@ -328,8 +330,10 @@ public final class Main {
    */
   private void activateEndpoints() {
     final List<Endpoint> endpoints = new ArrayList<>();
-    try (InputStream endpoint_stream = 
-        ClassLoader.getSystemResourceAsStream(ENDPOINT_CLASSES)) {
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
+    try (InputStream endpoint_stream =
+                 classLoader.getResourceAsStream(ENDPOINT_CLASSES)) {
       if (endpoint_stream == null) {
         Main.LOGGER.error("could not load list of entity classes");          
       } else {
@@ -450,9 +454,10 @@ public final class Main {
    */
   private List<County> initializeCounties() {
     final Properties properties = new Properties();
+
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
     try {
-      properties.load(ClassLoader.
-                      getSystemResourceAsStream(static_properties.getProperty(COUNTY_IDS)));
+      properties.load(classLoader.getResourceAsStream(static_properties.getProperty(COUNTY_IDS)));
     } catch (final IOException e) {
       throw new IllegalStateException("Error loading county IDs, aborting.", e);
     }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/persistence/Persistence.java
@@ -281,8 +281,8 @@ public final class Persistence {
 
       // create metadata sources and metadata
       final MetadataSources sources = new MetadataSources(service_registry);
-      try (InputStream entity_stream =
-               ClassLoader.getSystemResourceAsStream(ENTITY_CLASSES)) {
+      ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+      try (InputStream entity_stream = classLoader.getResourceAsStream(ENTITY_CLASSES)) {
         if (entity_stream == null) {
           Main.LOGGER.error("could not load list of entity classes");
         } else {

--- a/server/eclipse-project/src/test/java/us/freeandfair/corla/query/Setup.java
+++ b/server/eclipse-project/src/test/java/us/freeandfair/corla/query/Setup.java
@@ -21,10 +21,12 @@ public class Setup {
   public static final Properties properties = new Properties();
 
   public static void setProperties(){
+    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+
     try {
-    properties.load(ClassLoader.getSystemResourceAsStream(DEFAULT_PROPERTIES));
+    properties.load(classLoader.getResourceAsStream(DEFAULT_PROPERTIES));
     // overrides database name
-    properties.load(ClassLoader.getSystemResourceAsStream(TEST_PROPERTIES));
+    properties.load(classLoader.getResourceAsStream(TEST_PROPERTIES));
 
     Persistence.setProperties(properties);
     } catch (final IOException e) {


### PR DESCRIPTION
this was needed to get the hibernate entity classes loading on our new deploy environment.  tests appear to be working now for our deploy, which is exciting!  I don't expect these changes to cause any change in application behavior.

see https://github.com/DemocracyDevelopers/colorado-rla/issues/213