### PR TITLE
Add assertion tables to database reset queries

### DIFF
--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/query/DatabaseResetQueries.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/query/DatabaseResetQueries.java
@@ -12,6 +12,7 @@
 package us.freeandfair.corla.query;
 
 import javax.persistence.Cache;
+import javax.persistence.PersistenceException;
 
 import org.hibernate.Session;
 
@@ -75,7 +76,11 @@ public final class DatabaseResetQueries {
         "round",
         "audit_board",
         "county_dashboard",
-        "uploaded_file"
+        "uploaded_file",
+        "assertion",
+        "assertion_assumed_continuing",
+        "assertion_discrepancies",
+        "generate_assertions_summary"
     };
 
     for (final String t : tables) {


### PR DESCRIPTION
this is what i've been using to reset my database (using the reset db button whose functionality is on an unmerged branch).  I'm unsure how devops will be resetting the database in our production environment so I have a note to discuss that with them later, but this should work for us locally.