### PR TITLE
92 client UI for irv audit ballots review

### DIFF
--- a/client/screen.css
+++ b/client/screen.css
@@ -630,6 +630,17 @@ th.rla-county-contest-info {
     grid-template-columns: 2fr 1fr;
 }
 
+.contest-choice-review-grid-irv {
+    display: grid;
+    grid-column-gap: 1rem;
+    grid-template-columns: 5fr 1fr;
+}
+
+.contest-choice-review-grid-irv > .contest-choice-selection {
+    /* Disable hover and cursor changes for review page */
+    pointer-events: none;
+}
+
 .contest-choice-review {
     display: grid;
     grid-column-gap: 1rem;

--- a/client/src/component/County/Audit/Wizard/ReviewStage.tsx
+++ b/client/src/component/County/Audit/Wizard/ReviewStage.tsx
@@ -123,11 +123,13 @@ const BallotContestReview = (props: BallotContestReviewProps) => {
         }
 
         if (description === 'IRV') {
+            // convert props to ChoicesProps for IRV Display
             const irvChoicesProps: ChoicesProps = {
                 choices: contest.choices,
                 description,
                 marks,
                 noConsensus,
+                // null OnClick for review stage since clicking should not change markings
                 updateBallotMarks: () => null,
             };
 
@@ -151,7 +153,7 @@ const BallotContestReview = (props: BallotContestReviewProps) => {
           <strong><div className='contest-name'>{ contest.name }</div></strong>
           <strong><div>{ contest.description }</div></strong>
         </div>
-        <div className='contest-choice-review-grid'>
+        <div className={'contest-choice-review-grid' + (description === 'IRV' ? '-irv' : '')}>
           { noConsensus ? noConsensusDiv : renderMarkedChoices() }
           <div className='edit-button'>
             <EditButton back={ back } />

--- a/client/src/component/County/Audit/Wizard/ReviewStage.tsx
+++ b/client/src/component/County/Audit/Wizard/ReviewStage.tsx
@@ -4,6 +4,7 @@ import * as _ from 'lodash';
 
 import { Button, Icon, Intent } from '@blueprintjs/core';
 
+import IrvChoiceForm from 'corla/component/County/Audit/Wizard/IrvChoiceForm';
 import SubmittingACVR from './SubmittingACVR';
 
 interface EditButtonProps {
@@ -75,7 +76,7 @@ interface BallotContestReviewProps {
 const BallotContestReview = (props: BallotContestReviewProps) => {
     const { back, contest, marks } = props;
     const { comments, noConsensus } = marks;
-    const { votesAllowed } = contest;
+    const { votesAllowed, description } = contest;
 
     const markedChoices: County.ACVRChoices = _.pickBy(marks.choices);
     const votesMarked = _.size(markedChoices);
@@ -117,6 +118,22 @@ const BallotContestReview = (props: BallotContestReviewProps) => {
                         { markedChoiceDivs.length ? markedChoiceDivs : noMarksDiv }
                     </div>
                     <strong>Overvote</strong> for this contest.
+                </div>
+            );
+        }
+
+        if (description === 'IRV') {
+            const irvChoicesProps: ChoicesProps = {
+                choices: contest.choices,
+                description,
+                marks,
+                noConsensus,
+                updateBallotMarks: () => null,
+            };
+
+            return (
+                <div className='contest-choice-selection'>
+                    { IrvChoiceForm(irvChoicesProps) }
                 </div>
             );
         }


### PR DESCRIPTION
This should now show the same numbered grid on the review page as it does in the previous audit step, with room made for the "Edit" button and styling/click events altered.