### PR TITLE
235 estimate sample sizes endpoint seems to skip canonicalization step

### DIFF
--- a/client/src/action/dos/fetchContestsIgnoreManifests.ts
+++ b/client/src/action/dos/fetchContestsIgnoreManifests.ts
@@ -3,13 +3,12 @@ import { endpoint } from 'corla/config';
 import createFetchAction from 'corla/action/createFetchAction';
 
 // A copy of `fetchContests.ts`, except that it sets ignoreManifests=true.
-const url = endpoint('contest')
-    + '?ignoreManifests=true'
+const url = endpoint('contest') + '?ignoreManifests=true'
 
 export default createFetchAction({
-    failType: 'DOS_FETCH_CONTESTS_FAIL',
-    networkFailType: 'DOS_FETCH_CONTESTS_NETWORK_FAIL',
-    okType: 'DOS_FETCH_CONTESTS_OK',
-    sendType: 'DOS_FETCH_CONTESTS_SEND',
+    failType: 'DOS_FETCH_CONTESTS_IGNORE_MANIFESTS_FAIL',
+    networkFailType: 'DOS_FETCH_CONTESTS_IGNORE_MANIFESTS_NETWORK_FAIL',
+    okType: 'DOS_FETCH_CONTESTS_IGNORE_MANIFESTS_OK',
+    sendType: 'DOS_FETCH_CONTESTS_IGNORE_MANIFESTS_SEND',
     url,
 });

--- a/client/src/action/dos/fetchContestsIgnoreManifests.ts
+++ b/client/src/action/dos/fetchContestsIgnoreManifests.ts
@@ -2,7 +2,9 @@ import { endpoint } from 'corla/config';
 
 import createFetchAction from 'corla/action/createFetchAction';
 
-const url = endpoint('contest');
+// A copy of `fetchContests.ts`, except that it sets ignoreManifests=true.
+const url = endpoint('contest')
+    + '?ignoreManifests=true'
 
 export default createFetchAction({
     failType: 'DOS_FETCH_CONTESTS_FAIL',

--- a/client/src/component/DOS/DefineAudit/StandardizeChoicesPage.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeChoicesPage.tsx
@@ -58,14 +58,14 @@ interface UpdateFormMessage {
 }
 
 interface TableProps {
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     formData: DOS.Form.StandardizeChoices.FormData;
     rows: DOS.Form.StandardizeChoices.Row[];
     updateFormData: (msg: UpdateFormMessage) => void;
 }
 
 const Table = (props: TableProps) => {
-    const { contests, formData, rows, updateFormData } = props;
+    const { contestsIgnoringManifests, formData, rows, updateFormData } = props;
 
     return (
         <table className='pt-html-table pt-html-table-striped'>
@@ -77,7 +77,7 @@ const Table = (props: TableProps) => {
                     <th>Standardized Choice Name</th>
                 </tr>
             </thead>
-            <TableBody contests={ contests }
+            <TableBody contestsIgnoringManifests={ contestsIgnoringManifests }
                        rows={ rows }
                        formData={ formData }
                        updateFormData={ updateFormData } />
@@ -86,7 +86,7 @@ const Table = (props: TableProps) => {
 };
 
 interface TableBodyProps {
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     formData: DOS.Form.StandardizeChoices.FormData;
     rows: DOS.Form.StandardizeChoices.Row[];
     updateFormData: (msg: UpdateFormMessage) => void;
@@ -160,7 +160,7 @@ const TableRow = (props: TableRowProps) => {
 
 interface PageProps {
     areChoicesLoaded: boolean;
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     rows: DOS.Form.StandardizeChoices.Row[];
     forward: (x: DOS.Form.StandardizeChoices.FormData) => void;
     back: () => void;
@@ -226,7 +226,7 @@ class Page extends React.Component<PageProps, PageState> {
         const {
             areChoicesLoaded,
             back,
-            contests,
+            contestsIgnoringManifests,
             rows,
             forward,
         } = this.props;
@@ -250,7 +250,7 @@ class Page extends React.Component<PageProps, PageState> {
                             selections and move forward.
                         </p>
 
-                        <Table contests={ contests }
+                        <Table contestsIgnoringManifests={ contestsIgnoringManifests }
                                formData={ this.state.formData }
                                rows={ rows }
                                updateFormData={ this.updateFormData } />

--- a/client/src/component/DOS/DefineAudit/StandardizeChoicesPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeChoicesPageContainer.tsx
@@ -21,10 +21,10 @@ import counties from 'corla/data/counties';
  * something that can be easily displayed in a tabular format.
  */
 const flattenContests = (
-    contests: DOS.Contests,
+    contestsIgnoringManifests: DOS.Contests,
     canonicalChoices: DOS.CanonicalChoices,
 ): DOS.Form.StandardizeChoices.Row[] => {
-    return _.flatMap(contests, (contest: Contest) => {
+    return _.flatMap(contestsIgnoringManifests, (contest: Contest) => {
         return _.map(contest.choices, (choice: ContestChoice, idx) => {
             return {
                 choiceIndex: idx,
@@ -56,7 +56,7 @@ const filterRows = (
 interface Props {
     areChoicesLoaded: boolean;
     asm: DOS.ASMState;
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     canonicalChoices: DOS.CanonicalChoices;
     history: History;
 }
@@ -66,7 +66,7 @@ const PageContainer = (props: Props) => {
         areChoicesLoaded,
         asm,
         canonicalChoices,
-        contests,
+        contestsIgnoringManifests,
         history,
     } = props;
 
@@ -77,7 +77,7 @@ const PageContainer = (props: Props) => {
         }
         isRequestInProgress = true;
 
-        standardizeChoices(contests, data).then(r => {
+        standardizeChoices(contestsIgnoringManifests, data).then(r => {
             isRequestInProgress = false;
             // use the result here
             if (r.ok) {
@@ -96,7 +96,7 @@ const PageContainer = (props: Props) => {
 
     function getNextPath() {
         // Only route to Assertion Generation page if IRV contests exist
-        if (Object.values(contests).some(contest => contest.description === 'IRV')) {
+        if (Object.values(contestsIgnoringManifests).some(contest => contest.description === 'IRV')) {
             return '/sos/audit/generate-assertions';
         } else {
             return '/sos/audit/estimate-sample-sizes';
@@ -110,7 +110,7 @@ const PageContainer = (props: Props) => {
     let rows: DOS.Form.StandardizeChoices.Row[] = [];
 
     if (areChoicesLoaded) {
-        rows = filterRows(flattenContests(contests, canonicalChoices));
+        rows = filterRows(flattenContests(contestsIgnoringManifests, canonicalChoices));
 
         if (_.isEmpty(rows)) {
             return <Redirect to={ getNextPath() } />;
@@ -119,15 +119,15 @@ const PageContainer = (props: Props) => {
 
     return <StandardizeChoicesPage areChoicesLoaded={ areChoicesLoaded }
                                    back={ previousPage }
-                                   contests={ contests }
+                                   contestsIgnoringManifests={ contestsIgnoringManifests }
                                    rows={ rows }
                                    forward={ nextPage } />;
 };
 
 const mapStateToProps = (state: DOS.AppState) => {
-    const contests = state.contests;
+    const contestsIgnoringManifests = state.contestsIgnoringManifests;
     const canonicalChoices = state.canonicalChoices;
-    const areChoicesLoaded = !_.isEmpty(contests)
+    const areChoicesLoaded = !_.isEmpty(contestsIgnoringManifests)
         && !_.isEmpty(canonicalChoices)
         && !state.standardizingContests;
 
@@ -135,7 +135,7 @@ const mapStateToProps = (state: DOS.AppState) => {
         areChoicesLoaded,
         asm: state.asm,
         canonicalChoices,
-        contests,
+        contestsIgnoringManifests,
     };
 };
 

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPage.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPage.tsx
@@ -58,14 +58,14 @@ interface UpdateFormMessage {
 }
 
 interface TableProps {
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     canonicalContests: DOS.CanonicalContests;
     formData: DOS.Form.StandardizeContests.FormData;
     updateFormData: (msg: UpdateFormMessage) => void;
 }
 
 const StandardizeContestsTable = (props: TableProps) => {
-    const { canonicalContests, contests, formData, updateFormData } = props;
+    const { canonicalContests, contestsIgnoringManifests, formData, updateFormData } = props;
 
     return (
         <table className='pt-html-table pt-html-table-striped'>
@@ -76,7 +76,7 @@ const StandardizeContestsTable = (props: TableProps) => {
                     <th>Standardized Contest Name</th>
                 </tr>
             </thead>
-            <ContestBody contests={ contests }
+            <ContestBody contestsIgnoringManifests={ contestsIgnoringManifests }
                          canonicalContests={ canonicalContests }
                          formData={ formData }
                          updateFormData={ updateFormData } />
@@ -85,16 +85,16 @@ const StandardizeContestsTable = (props: TableProps) => {
 };
 
 interface BodyProps {
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     canonicalContests: DOS.CanonicalContests;
     formData: DOS.Form.StandardizeContests.FormData;
     updateFormData: (msg: UpdateFormMessage) => void;
 }
 
 const ContestBody = (props: BodyProps) => {
-    const { canonicalContests, contests, formData, updateFormData } = props;
+    const { canonicalContests, contestsIgnoringManifests, formData, updateFormData } = props;
 
-    const rows = _.map(contests, c => {
+    const rows = _.map(contestsIgnoringManifests, c => {
         return <ContestRow key={ c.id }
                            contest={ c }
                            canonicalContests={ canonicalContests }
@@ -150,7 +150,7 @@ const ContestRow = (props: ContestRowProps) => {
 interface PageProps {
     areCVRsLoaded: boolean;
     canonicalContests: DOS.CanonicalContests;
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     forward: (x: DOS.Form.StandardizeContests.FormData) => void;
     back: () => void;
 }
@@ -178,12 +178,12 @@ class StandardizeContestsPage extends React.Component<PageProps, PageState> {
         if (!prevProps.areCVRsLoaded && this.props.areCVRsLoaded) {
             const {
                 canonicalContests,
-                contests,
+                contestsIgnoringManifests,
             } = this.props;
 
             const formData: DOS.Form.StandardizeContests.FormData = {};
 
-            _.forEach(contests, contest => {
+            _.forEach(contestsIgnoringManifests, contest => {
                 const countyName = counties[contest.countyId].name;
                 const standards = canonicalContests[countyName];
 
@@ -203,7 +203,7 @@ class StandardizeContestsPage extends React.Component<PageProps, PageState> {
             areCVRsLoaded,
             back,
             canonicalContests,
-            contests,
+            contestsIgnoringManifests,
             forward,
         } = this.props;
 
@@ -226,7 +226,7 @@ class StandardizeContestsPage extends React.Component<PageProps, PageState> {
                         </p>
 
                         <StandardizeContestsTable canonicalContests={ canonicalContests }
-                                                  contests={ contests }
+                                                  contestsIgnoringManifests={ contestsIgnoringManifests }
                                                   formData={ this.state.formData }
                                                   updateFormData={ this.updateFormData } />
                     </Card>

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPage.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPage.tsx
@@ -148,7 +148,7 @@ const ContestRow = (props: ContestRowProps) => {
 };
 
 interface PageProps {
-    areContestsLoaded: boolean;
+    areCVRsLoaded: boolean;
     canonicalContests: DOS.CanonicalContests;
     contests: DOS.Contests;
     forward: (x: DOS.Form.StandardizeContests.FormData) => void;
@@ -175,7 +175,7 @@ class StandardizeContestsPage extends React.Component<PageProps, PageState> {
      * form state with initial contest guesses.
      */
     public componentDidUpdate(prevProps: PageProps, prevState: PageState) {
-        if (!prevProps.areContestsLoaded && this.props.areContestsLoaded) {
+        if (!prevProps.areCVRsLoaded && this.props.areCVRsLoaded) {
             const {
                 canonicalContests,
                 contests,
@@ -200,7 +200,7 @@ class StandardizeContestsPage extends React.Component<PageProps, PageState> {
 
     public render() {
         const {
-            areContestsLoaded,
+            areCVRsLoaded,
             back,
             canonicalContests,
             contests,
@@ -209,7 +209,7 @@ class StandardizeContestsPage extends React.Component<PageProps, PageState> {
 
         let main = null;
 
-        if (areContestsLoaded) {
+        if (areCVRsLoaded) {
             main =
                 <div>
                     <Breadcrumbs />

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -101,7 +101,6 @@ const mapStateToProps = (state: DOS.AppState) => {
     const areCVRsLoaded = !_.isEmpty(contestsIgnoringManifests)
         && !_.isEmpty(canonicalContests)
         && !state.settingAuditInfo;
-    console.log("contestsIgnoringManifests size = "+contestsIgnoringManifests.toString()+". State = "+state.asm);
 
     return {
         areCVRsLoaded,

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -96,8 +96,9 @@ const StandardizeContestsPageContainer = (props: Props) => {
 
 const mapStateToProps = (state: DOS.AppState) => {
     const canonicalContests = state.canonicalContests;
+    const contestsIgnoringAbsentManifests = state.contestsIgnoringManifests;
     const contests = state.contests;
-    const areCVRsLoaded = !_.isEmpty(contests)
+    const areCVRsLoaded = !_.isEmpty(contestsIgnoringAbsentManifests)
         && !_.isEmpty(canonicalContests)
         && !state.settingAuditInfo;
 
@@ -105,7 +106,7 @@ const mapStateToProps = (state: DOS.AppState) => {
         areCVRsLoaded,
         asm: state.asm,
         canonicalContests,
-        contests,
+        contestsIgnoringAbsentManifests,
     };
 };
 

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -23,10 +23,10 @@ const NEXT_PATH = '/sos/audit/standardize-choices';
 const PREV_PATH = '/sos/audit';
 
 const contestsToDisplay = (
-    contests: DOS.Contests,
+    contestsIgnoringManifests: DOS.Contests,
     canonicalContests: DOS.CanonicalContests,
 ): DOS.Contests => {
-    return _.reduce(contests, (acc: DOS.Contests, contest: Contest) => {
+    return _.reduce(contestsIgnoringManifests, (acc: DOS.Contests, contest: Contest) => {
         const countyName = counties[contest.countyId].name;
         const countyStandards = canonicalContests[countyName] || [];
 
@@ -42,7 +42,7 @@ const contestsToDisplay = (
 interface Props {
     areCVRsLoaded: boolean;
     asm: DOS.ASMState;
-    contests: DOS.Contests;
+    contestsIgnoringManifests: DOS.Contests;
     canonicalContests: DOS.CanonicalContests;
     history: History;
 }
@@ -52,12 +52,12 @@ const StandardizeContestsPageContainer = (props: Props) => {
         areCVRsLoaded,
         asm,
         canonicalContests,
-        contests,
+        contestsIgnoringManifests,
         history,
     } = props;
 
     const nextPage = (data: DOS.Form.StandardizeContests.FormData) => {
-        standardizeContests(contests, data).then(function(r) {
+        standardizeContests(contestsIgnoringManifests, data).then(function(r) {
             // use the result here
             if (r.ok) {
                 history.push(NEXT_PATH);
@@ -80,7 +80,7 @@ const StandardizeContestsPageContainer = (props: Props) => {
     let filteredContests = {};
 
     if (areCVRsLoaded) {
-        filteredContests = contestsToDisplay(contests, canonicalContests);
+        filteredContests = contestsToDisplay(contestsIgnoringManifests, canonicalContests);
 
         if (_.isEmpty(filteredContests)) {
             return <Redirect to={ NEXT_PATH } />;
@@ -90,23 +90,24 @@ const StandardizeContestsPageContainer = (props: Props) => {
     return <StandardizeContestsPage areCVRsLoaded={ areCVRsLoaded }
                                     back={ previousPage }
                                     canonicalContests={ canonicalContests }
-                                    contests={ filteredContests }
+                                    contestsIgnoringManifests={ filteredContests }
                                     forward={ nextPage } />;
 };
 
 const mapStateToProps = (state: DOS.AppState) => {
     const canonicalContests = state.canonicalContests;
-    const contestsIgnoringAbsentManifests = state.contestsIgnoringManifests;
-    const contests = state.contests;
-    const areCVRsLoaded = !_.isEmpty(contestsIgnoringAbsentManifests)
+    const contestsIgnoringManifests = state.contestsIgnoringManifests;
+    const contests = state.contests; // VT: Now apparently unused.
+    const areCVRsLoaded = !_.isEmpty(contestsIgnoringManifests)
         && !_.isEmpty(canonicalContests)
         && !state.settingAuditInfo;
+    console.log("contestsIgnoringManifests size = "+contestsIgnoringManifests.toString()+". State = "+state.asm);
 
     return {
         areCVRsLoaded,
         asm: state.asm,
         canonicalContests,
-        contestsIgnoringAbsentManifests,
+        contestsIgnoringManifests,
     };
 };
 

--- a/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
+++ b/client/src/component/DOS/DefineAudit/StandardizeContestsPageContainer.tsx
@@ -40,7 +40,7 @@ const contestsToDisplay = (
 };
 
 interface Props {
-    areContestsLoaded: boolean;
+    areCVRsLoaded: boolean;
     asm: DOS.ASMState;
     contests: DOS.Contests;
     canonicalContests: DOS.CanonicalContests;
@@ -49,7 +49,7 @@ interface Props {
 
 const StandardizeContestsPageContainer = (props: Props) => {
     const {
-        areContestsLoaded,
+        areCVRsLoaded,
         asm,
         canonicalContests,
         contests,
@@ -79,7 +79,7 @@ const StandardizeContestsPageContainer = (props: Props) => {
 
     let filteredContests = {};
 
-    if (areContestsLoaded) {
+    if (areCVRsLoaded) {
         filteredContests = contestsToDisplay(contests, canonicalContests);
 
         if (_.isEmpty(filteredContests)) {
@@ -87,7 +87,7 @@ const StandardizeContestsPageContainer = (props: Props) => {
         }
     }
 
-    return <StandardizeContestsPage areContestsLoaded={ areContestsLoaded }
+    return <StandardizeContestsPage areCVRsLoaded={ areCVRsLoaded }
                                     back={ previousPage }
                                     canonicalContests={ canonicalContests }
                                     contests={ filteredContests }
@@ -97,12 +97,12 @@ const StandardizeContestsPageContainer = (props: Props) => {
 const mapStateToProps = (state: DOS.AppState) => {
     const canonicalContests = state.canonicalContests;
     const contests = state.contests;
-    const areContestsLoaded = !_.isEmpty(contests)
+    const areCVRsLoaded = !_.isEmpty(contests)
         && !_.isEmpty(canonicalContests)
         && !state.settingAuditInfo;
 
     return {
-        areContestsLoaded,
+        areCVRsLoaded,
         asm: state.asm,
         canonicalContests,
         contests,

--- a/client/src/reducer/defaultState.ts
+++ b/client/src/reducer/defaultState.ts
@@ -29,6 +29,7 @@ export function dosState(): DOS.AppState {
         auditTypes: {},
         auditedContests: {},
         contests: {},
+        contestsIgnoringManifests: {},
         countyStatus: {},
         type: 'DOS',
         generateAssertionsSummaries: [],

--- a/client/src/reducer/dos/contestFetchIgnoreManifestsOk.ts
+++ b/client/src/reducer/dos/contestFetchIgnoreManifestsOk.ts
@@ -1,0 +1,15 @@
+import { parse } from 'corla/adapter/contestFetch';
+
+// Identical to contestFetch, but setting the contestsIgnoringManfiests field.
+// There's no need to change .DOSFectchContestOK or the parser, because both of these are the same
+// regardless of whether we ignore manifests - i.e. the contest data is the same.
+export default function contestFetchOk(
+    state: DOS.AppState,
+    action: Action.DOSFetchContestsOk,
+): DOS.AppState {
+    const nextState = { ...state };
+
+    nextState.contestsIgnoringManifests = parse(action.data);
+
+    return nextState;
+}

--- a/client/src/reducer/dos/contestFetchIgnoreManifestsOk.ts
+++ b/client/src/reducer/dos/contestFetchIgnoreManifestsOk.ts
@@ -5,7 +5,7 @@ import { parse } from 'corla/adapter/contestFetch';
 // regardless of whether we ignore manifests - i.e. the contest data is the same.
 export default function contestFetchOk(
     state: DOS.AppState,
-    action: Action.DOSFetchContestsOk,
+    action: Action.DOSFetchContestsIgnoreManifestsOk,
 ): DOS.AppState {
     const nextState = { ...state };
 

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -71,6 +71,10 @@ export default function root(state: AppState, action: Action.App) {
         return dosContestFetchOk(state as DOS.AppState, action);
     }
 
+    case 'DOS_FETCH_CONTESTS_IGNORE_MANIFESTS_OK': {
+        return dosContestFetchIgnoreManifestsOk(state as DOS.AppState, action);
+    }
+
     case 'DOS_LOGIN_OK': {
         return dosLoginOk(state as LoginAppState);
     }

--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -15,6 +15,7 @@ import uploadingBallotManifest from './county/uploadingBallotManifest';
 import uploadingCvrExport from './county/uploadingCvrExport';
 
 import dosContestFetchOk from './dos/contestFetchOk';
+import dosContestFetchIgnoreManifestsOk from './dos/contestFetchIgnoreManifestsOk';
 import dosDashboardRefreshOk from './dos/dashboardRefreshOk';
 import dosDeleteFileOk from './dos/deleteFileOk';
 import fetchDOSASMStateOk from './dos/fetchDOSASMStateOk';

--- a/client/src/saga/dos/sync.ts
+++ b/client/src/saga/dos/sync.ts
@@ -16,7 +16,6 @@ function* contestOverviewSaga() {
     });
 }
 
-// TODO (VT): I believe this is unused.
 function* contestDetailSaga() {
     yield takeLatest('DOS_COUNTY_DETAIL_SYNC', () => {
         fetchContests();

--- a/client/src/saga/dos/sync.ts
+++ b/client/src/saga/dos/sync.ts
@@ -6,14 +6,17 @@ import createPollSaga from 'corla/saga/createPollSaga';
 
 import dashboardRefresh from 'corla/action/dos/dashboardRefresh';
 import fetchContests from 'corla/action/dos/fetchContests';
+import fetchContestsIgnoreManifests from 'corla/action/dos/fetchContestsIgnoreManifests';
 
 function* contestOverviewSaga() {
     yield takeLatest('DOS_CONTEST_OVERVIEW_SYNC', () => {
         fetchContests();
+        fetchContestsIgnoreManifests();
         dashboardRefresh();
     });
 }
 
+// TODO (VT): I believe this is unused.
 function* contestDetailSaga() {
     yield takeLatest('DOS_COUNTY_DETAIL_SYNC', () => {
         fetchContests();
@@ -31,6 +34,7 @@ function* countyOverviewSaga() {
 
 const DOS_POLL_DELAY = config.pollDelay;
 
+// TODO (VT): I belive this is also unused.
 const dashboardPollSaga = createPollSaga(
     [dashboardRefresh, fetchContests],
     'DOS_DASHBOARD_POLL_START',

--- a/client/src/saga/dos/sync.ts
+++ b/client/src/saga/dos/sync.ts
@@ -20,6 +20,7 @@ function* contestOverviewSaga() {
 function* contestDetailSaga() {
     yield takeLatest('DOS_COUNTY_DETAIL_SYNC', () => {
         fetchContests();
+        fetchContestsIgnoreManifests();
         dashboardRefresh();
     });
 }

--- a/client/src/saga/sync.ts
+++ b/client/src/saga/sync.ts
@@ -6,6 +6,7 @@ import fetchCountyASMState from 'corla/action/county/fetchCountyASMState';
 
 import dosDashboardRefresh from 'corla/action/dos/dashboardRefresh';
 import dosFetchContests from 'corla/action/dos/fetchContests';
+import dosFetchContestsIgnoreManifests from 'corla/action/dos/fetchContestsIgnoreManifests';
 
 function* countyRefresh() {
     yield all([
@@ -19,6 +20,7 @@ function* dosRefresh() {
     yield all([
         call(dosDashboardRefresh),
         call(dosFetchContests),
+        call(dosFetchContestsIgnoreManifests),
     ]);
 }
 

--- a/client/src/types/action.d.ts
+++ b/client/src/types/action.d.ts
@@ -18,6 +18,7 @@ declare namespace Action {
         | DOSDashboardRefreshOk
         | DOSDeleteFileOk
         | DOSFetchContestsOk
+        | DOSFetchContestsIgnoreManifestsOk
         | DOSLoginOk
         | DeleteFileOK
         | FetchAuditBoardASMStateOk
@@ -115,6 +116,11 @@ declare namespace Action {
 
     interface DOSFetchContestsOk {
         type: 'DOS_FETCH_CONTESTS_OK';
+        data: any;
+    }
+
+    interface DOSFetchContestsIgnoreManifestsOk {
+        type: 'DOS_FETCH_CONTESTS_IGNORE_MANIFESTS_OK';
         data: any;
     }
 

--- a/client/src/types/dos.d.ts
+++ b/client/src/types/dos.d.ts
@@ -4,6 +4,7 @@ declare namespace DOS {
         auditedContests: DOS.AuditedContests;
         auditTypes: ContestAuditTypes;
         contests: DOS.Contests;
+        contestsIgnoringManifests: DOS.Contests;
         countyStatus: DOS.CountyStatuses;
         canonicalContests?: DOS.CanonicalContests;
         canonicalChoices?: DOS.CanonicalChoices;

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -77,7 +77,7 @@ public class ContestDownload extends AbstractEndpoint {
   /**
    * Query specifier for ignoring (the absence of) manifests.
    */
-  private static final String IGNORE_MANIFEST = "ignoreManifests";
+  private static final String IGNORE_MANIFESTS = "ignoreManifests";
 
   /**
    * {@inheritDoc}
@@ -90,7 +90,7 @@ public class ContestDownload extends AbstractEndpoint {
     if (validateParameters(the_request)) {
 
       final boolean ignoreManifests
-          = Boolean.parseBoolean(the_request.queryParamOrDefault(IGNORE_MANIFEST, "false"));
+          = Boolean.parseBoolean(the_request.queryParamOrDefault(IGNORE_MANIFESTS, "false"));
       final Set<County> county_set = new HashSet<>();
       for (final CountyDashboard cdb : Persistence.getAll(CountyDashboard.class)) {
         // If 'ignoreManifests' has been requested, then counties that have only CVRs uploaded are
@@ -128,7 +128,7 @@ public class ContestDownload extends AbstractEndpoint {
   @Override
   protected boolean validateParameters(final Request the_request) {
 
-    final String ignoreManifests = the_request.queryParams(IGNORE_MANIFEST);
+    final String ignoreManifests = the_request.queryParams(IGNORE_MANIFESTS);
     return ignoreManifests == null
         || ignoreManifests.equalsIgnoreCase("true")
         || ignoreManifests.equalsIgnoreCase("false");

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -82,6 +82,9 @@ public class ContestDownload extends AbstractEndpoint {
     // only return contests for counties that have finished their uploads
     final Set<County> county_set = new HashSet<>();
     for (final CountyDashboard cdb : Persistence.getAll(CountyDashboard.class)) {
+      // FIXME (VT): Is there any reason we need the manifest file to have been uploaded?
+      // Is there any other part of the (client or server) code that assumes the manifest must have
+      // been uploaded in order to get this?
       if (cdb.manifestFile() != null && cdb.cvrFile() != null) {
         county_set.add(cdb.county());
       }

--- a/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
+++ b/server/eclipse-project/src/main/java/us/freeandfair/corla/endpoint/ContestDownload.java
@@ -75,36 +75,62 @@ public class ContestDownload extends AbstractEndpoint {
   }
 
   /**
+   * Query specifier for ignoring (the absence of) manifests.
+   */
+  private static final String IGNORE_MANIFEST = "ignoreManifests";
+
+  /**
    * {@inheritDoc}
    */
   @Override
   public String endpointBody(final Request the_request, final Response the_response) {
-    // only return contests for counties that have finished their uploads
-    final Set<County> county_set = new HashSet<>();
-    for (final CountyDashboard cdb : Persistence.getAll(CountyDashboard.class)) {
-      // FIXME (VT): Is there any reason we need the manifest file to have been uploaded?
-      // Is there any other part of the (client or server) code that assumes the manifest must have
-      // been uploaded in order to get this?
-      if (cdb.manifestFile() != null && cdb.cvrFile() != null) {
-        county_set.add(cdb.county());
+    // Only return contests for counties that have finished their uploads.
+    // That means CVRs and manifests, unless the 'ignoreManifests' flag has been set in the request,
+    // in which case CVRs only are OK.
+    if (validateParameters(the_request)) {
+
+      final boolean ignoreManifests
+          = Boolean.parseBoolean(the_request.queryParamOrDefault(IGNORE_MANIFEST, "false"));
+      final Set<County> county_set = new HashSet<>();
+      for (final CountyDashboard cdb : Persistence.getAll(CountyDashboard.class)) {
+        // If 'ignoreManifests' has been requested, then counties that have only CVRs uploaded are
+        // included. Otherwise, both manifests and CVRs are required.
+        if ( (cdb.manifestFile() != null || ignoreManifests) && cdb.cvrFile() != null) {
+          county_set.add(cdb.county());
+        }
       }
-    }
-    final List<Contest> contest_list = ContestQueries.forCounties(county_set);
-    try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
-         BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
-         JsonWriter jw = new JsonWriter(bw)) {
-      jw.beginArray();
-      for (final Contest contest : contest_list) {
-        jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(contest)));
-        Persistence.evict(contest);
-      } 
-      jw.endArray();
-      jw.flush();
-      jw.close();
-      ok(the_response);
-    } catch (final IOException e) {
-      serverError(the_response, "Unable to stream response");
+      final List<Contest> contest_list = ContestQueries.forCounties(county_set);
+      try (OutputStream os = SparkHelper.getRaw(the_response).getOutputStream();
+           BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(os, "UTF-8"));
+           JsonWriter jw = new JsonWriter(bw)) {
+        jw.beginArray();
+        for (final Contest contest : contest_list) {
+          jw.jsonValue(Main.GSON.toJson(Persistence.unproxy(contest)));
+          Persistence.evict(contest);
+        }
+        jw.endArray();
+        jw.flush();
+        jw.close();
+        ok(the_response);
+      } catch (final IOException e) {
+        serverError(the_response, "Unable to stream response");
+      }
+    } else {
+      dataNotFound(the_response, "Invalid request parameters");
     }
     return my_endpoint_result.get();
+  }
+
+  /**
+   * Validates the query parameters. The only possible query parameter is ignoreManifests, which is
+   * optional and either true or false.
+   */
+  @Override
+  protected boolean validateParameters(final Request the_request) {
+
+    final String ignoreManifests = the_request.queryParams(IGNORE_MANIFEST);
+    return ignoreManifests == null
+        || ignoreManifests.equalsIgnoreCase("true")
+        || ignoreManifests.equalsIgnoreCase("false");
   }
 }

--- a/server/eclipse-project/src/test/resources/workflows/Boulder_loadCVRs.http
+++ b/server/eclipse-project/src/test/resources/workflows/Boulder_loadCVRs.http
@@ -28,12 +28,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="7-boulder-2023-plusByron-7.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/7-boulder-2023-plusByron-7.csv
+< ../CSVs/Demo1/7-boulder-2023-plusByron-7.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/Demo1/7-boulder-2023-plusByron-7.csv.sha256sum
+< ../CSVs/Demo1/7-boulder-2023-plusByron-7.csv.sha256sum
 --TheBoundary--
 
 > {%

--- a/server/eclipse-project/src/test/resources/workflows/Boulder_loadManifest.http
+++ b/server/eclipse-project/src/test/resources/workflows/Boulder_loadManifest.http
@@ -28,13 +28,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Boulder-IRV-Manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Boulder23/Boulder-IRV-Manifest.csv
+< ../CSVs/Boulder23/Boulder-IRV-Manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/Boulder23/Boulder-IRV-Manifest.csv.sha256sum
+< ../CSVs/Boulder23/Boulder-IRV-Manifest.csv.sha256sum
 --TheBoundary--
 
 > {%

--- a/server/eclipse-project/src/test/resources/workflows/demo1_defineAudit.http
+++ b/server/eclipse-project/src/test/resources/workflows/demo1_defineAudit.http
@@ -38,7 +38,7 @@ Content-Type: application/json
 }
 
 ### Request contests.
-GET http://localhost:8888/contest
+GET http://localhost:8888/contest?ignoreManifests=true
 Content-Type: text/plain
 
 > {%
@@ -49,19 +49,22 @@ Content-Type: text/plain
 ### the (real) client.
 ### Note that the set-contest-names endpoint is used for both contest names and candidate names,
 ### which are called separately.
+### Also note that we have to find the IDs by asking for the _wrong_ names, then put the right name
+### in the request.
 < {%
     import {getContestIDsWithCounties} from 'testScripts/testUtils';
     const contestIDData = getContestIDsWithCounties(client.global.get("contestJsonData"));
-    request.variables.set("BoulderMayoralID", contestIDData.get("City of Boulder Mayoral")[0][0]);
-    request.variables.set("BoulderCouncilID", contestIDData.get("City of Boulder Council")[0][0]);
-    request.variables.set("LafayetteCouncilID",  contestIDData.get("City of Lafayette City Council")[0][0]);
+    console.log("contestJsonData = "+client.global.get("contestJsonData"));
+    request.variables.set("BoulderMayoralID", contestIDData.get("City of Boulder Mayoral Candidates")[0][0]);
+    console.log("BoulderMayoralID = "+contestIDData.get("City of Boulder Mayoral Candidates")[0][0]);
+    request.variables.set("BoulderCouncilID", contestIDData.get("City of Boulder Council Candidates")[0][0]);
+    request.variables.set("LafayetteCouncilID",  contestIDData.get("City of Lafayette City Council Candidates")[0][0]);
     // U CO Regent is spread over Adams and Alamosa, so we have two contestIDs and we need
     // to match the corresponding county ID.
-    request.variables.set("U_CO_Regent_1_ID",  contestIDData.get("Regent of the University of Colorado")[0][0]);
-    request.variables.set("U_CO_Regent_1_County_ID",  contestIDData.get("Regent of the University of Colorado")[0][1]);
-    request.variables.set("U_CO_Regent_2_ID",  contestIDData.get("Regent of the University of Colorado")[1][0]);
-    request.variables.set("U_CO_Regent_2_County_ID",  contestIDData.get("Regent of the University of Colorado")[1][1]);
-
+    request.variables.set("U_CO_Regent_1_ID",  contestIDData.get("Regent of the University of Colorado - At Large")[0][0]);
+    request.variables.set("U_CO_Regent_1_County_ID",  contestIDData.get("Regent of the University of Colorado - At Large")[0][1]);
+    request.variables.set("U_CO_Regent_2_ID",  contestIDData.get("Regent of the University of Colorado - At Large")[1][0]);
+    request.variables.set("U_CO_Regent_2_County_ID",  contestIDData.get("Regent of the University of Colorado - At Large")[1][1]);
 %}
 POST http://localhost:8888/set-contest-names
 Content-Type: application/json

--- a/server/eclipse-project/src/test/resources/workflows/demo1_defineAudit.http
+++ b/server/eclipse-project/src/test/resources/workflows/demo1_defineAudit.http
@@ -24,8 +24,6 @@ Content-Type: application/json
 GET http://localhost:8888/dos-dashboard
 Content-Type: text/html
 
-
-
 ### Define the audit. This reads in from the canonical list contents hardcoded in the http-client.env file,
 ### though reading in from the demo1-canonical-list.csv file would be better.
 POST http://localhost:8888/update-audit-info
@@ -39,39 +37,12 @@ Content-Type: application/json
     "upload_file": [{"contents" : "{{demo1-canonical-list}}" }]
 }
 
-### Request contests we care about, search for IDs by name.
+### Request contests.
 GET http://localhost:8888/contest
 Content-Type: text/plain
 
 > {%
     client.global.set("contestJsonData", response.body);
-    import {getContestIDsWithCounties} from 'testScripts/testUtils';
-    // const jsonData = JSON.parse(response.body);
-
-   //  console.log("I work");
-
-    // Store the IDs of all the contests we care about, either for canonicalization or targeting.
-    const contestIDData = getContestIDsWithCounties(response.body);
-        /*
-            new ContestWithIDs("Byron Mayoral","ByronMayoralID"),
-        new ContestWithIDs("Kempsey Mayoral","KempseyMayoralID"),
-        new ContestWithIDs("City of Longmont - Mayor","LongmontMayoralID"),
-        new ContestWithIDs("City of Boulder Mayoral", "BoulderMayoralID"),
-        new ContestWithIDs("City of Boulder Council", "BoulderCouncilID"),
-        new ContestWithIDs("Regent of the University of Colorado", "U_CO_RegentID")
-
-
-        "Byron Mayoral",
-        "Kempsey Mayoral",
-        "City of Longmont - Mayor",
-        "City of Boulder Mayoral",
-        "City of Boulder Council",
-        "Regent of the University of Colorado"
-
-         */
-
-    client.global.set("contestIDData", contestIDData);
-
 %}
 
 ### Canonicalize contest names. This just matches what comes up when we do the obvious thing from

--- a/server/eclipse-project/src/test/resources/workflows/demo1_defineAudit.http
+++ b/server/eclipse-project/src/test/resources/workflows/demo1_defineAudit.http
@@ -39,13 +39,69 @@ Content-Type: application/json
     "upload_file": [{"contents" : "{{demo1-canonical-list}}" }]
 }
 
+### Request contests we care about, search for IDs by name.
+GET http://localhost:8888/contest
+Content-Type: text/plain
 
-### Canonicalize contest names. Doing nothing at the moment.
-### TODO: not sure why there's only the contest names, not the candidate names, in the .har file.
+> {%
+    client.global.set("contestJsonData", response.body);
+    import {getContestIDsWithCounties} from 'testScripts/testUtils';
+    // const jsonData = JSON.parse(response.body);
+
+   //  console.log("I work");
+
+    // Store the IDs of all the contests we care about, either for canonicalization or targeting.
+    const contestIDData = getContestIDsWithCounties(response.body);
+        /*
+            new ContestWithIDs("Byron Mayoral","ByronMayoralID"),
+        new ContestWithIDs("Kempsey Mayoral","KempseyMayoralID"),
+        new ContestWithIDs("City of Longmont - Mayor","LongmontMayoralID"),
+        new ContestWithIDs("City of Boulder Mayoral", "BoulderMayoralID"),
+        new ContestWithIDs("City of Boulder Council", "BoulderCouncilID"),
+        new ContestWithIDs("Regent of the University of Colorado", "U_CO_RegentID")
+
+
+        "Byron Mayoral",
+        "Kempsey Mayoral",
+        "City of Longmont - Mayor",
+        "City of Boulder Mayoral",
+        "City of Boulder Council",
+        "Regent of the University of Colorado"
+
+         */
+
+    client.global.set("contestIDData", contestIDData);
+
+%}
+
+### Canonicalize contest names. This just matches what comes up when we do the obvious thing from
+### the (real) client.
+### Note that the set-contest-names endpoint is used for both contest names and candidate names,
+### which are called separately.
+< {%
+    import {getContestIDsWithCounties} from 'testScripts/testUtils';
+    const contestIDData = getContestIDsWithCounties(client.global.get("contestJsonData"));
+    request.variables.set("BoulderMayoralID", contestIDData.get("City of Boulder Mayoral")[0][0]);
+    request.variables.set("BoulderCouncilID", contestIDData.get("City of Boulder Council")[0][0]);
+    request.variables.set("LafayetteCouncilID",  contestIDData.get("City of Lafayette City Council")[0][0]);
+    // U CO Regent is spread over Adams and Alamosa, so we have two contestIDs and we need
+    // to match the corresponding county ID.
+    request.variables.set("U_CO_Regent_1_ID",  contestIDData.get("Regent of the University of Colorado")[0][0]);
+    request.variables.set("U_CO_Regent_1_County_ID",  contestIDData.get("Regent of the University of Colorado")[0][1]);
+    request.variables.set("U_CO_Regent_2_ID",  contestIDData.get("Regent of the University of Colorado")[1][0]);
+    request.variables.set("U_CO_Regent_2_County_ID",  contestIDData.get("Regent of the University of Colorado")[1][1]);
+
+%}
 POST http://localhost:8888/set-contest-names
 Content-Type: application/json
 
-[]
+[
+  {"contestId":{{BoulderMayoralID}},"countyId":7,"name":"City of Boulder Mayoral"},
+  {"contestId":{{BoulderCouncilID}},"countyId":7,"name":"City of Boulder Council"},
+  {"contestId":{{LafayetteCouncilID}},"countyId":7,"name":"City of Lafayette City Council"},
+  {"contestId":{{U_CO_Regent_1_ID}},"countyId":{{U_CO_Regent_1_County_ID}},"name":"Regent of the University of Colorado"},
+  {"contestId":{{U_CO_Regent_2_ID}},"countyId":{{U_CO_Regent_2_County_ID}},"name":"Regent of the University of Colorado"}
+]
 
 ### Generate assertions.
 GET http://localhost:8888/generate-assertions?timeLimitSeconds=1
@@ -62,31 +118,15 @@ client.test("Response content-type is json", function() {
     });
 %}
 
-### Request contests, search for IDs by name.
-GET http://localhost:8888/contest
-Content-Type: text/plain
-
-> {%
-    const jsonData = JSON.parse(response.body);
-    for(var i=0; i < jsonData.length ; i++) {
-        // Note this will end up with the last one, and there are many. This seems to be how it works
-        // for statewide targeted contests.
-        if(jsonData[i]['name'] === "Byron Mayoral") {
-            client.log("Found Byron Mayoral, id="+jsonData[i]['id']);
-            client.global.set("ByronMayoralID", jsonData[i]['id']);
-        }
-        if(jsonData[i]['name'] === "Kempsey Mayoral") {
-            client.log("Found Kempsey Mayoral, id="+jsonData[i]['id']);
-            client.global.set("KempseyMayoralID", jsonData[i]['id']);
-        }
-        if(jsonData[i]['name'] === "City of Longmont - Mayor") {
-            client.log("Found City of Longmont - Mayor, id="+jsonData[i]['id']);
-            client.global.set("LongmontMayoralID", jsonData[i]['id']);
-        }
-    }
-%}
 
 ### Select contests to be targeted.
+< {%
+    import {getContestIDsWithCounties} from 'testScripts/testUtils';
+    const contestIDData = getContestIDsWithCounties(client.global.get("contestJsonData"));
+    request.variables.set("KempseyMayoralID", contestIDData.get("Kempsey Mayoral")[0][0]);
+    request.variables.set("ByronMayoralID", contestIDData.get("Byron Mayoral")[0][0]);
+    request.variables.set("LongmontMayoralID",  contestIDData.get("City of Longmont - Mayor")[0][0]);
+%}
 POST http://localhost:8888/select-contests
 Content-Type: application/json
 

--- a/server/eclipse-project/src/test/resources/workflows/demo1_loadCVRs.http
+++ b/server/eclipse-project/src/test/resources/workflows/demo1_loadCVRs.http
@@ -39,13 +39,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="1-adams-cvrexport-plusByron-1.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/1-adams-cvrexport-plusByron-1.csv
+< ../CSVs/Demo1/1-adams-cvrexport-plusByron-1.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/1-adams-cvrexport-plusByron-1.csv.sha256sum
+< ../CSVs/Demo1/1-adams-cvrexport-plusByron-1.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -98,13 +98,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="2-alamosa-cvrexport-plusByron-2.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/2-alamosa-cvrexport-plusByron-2.csv
+< ../CSVs/Demo1/2-alamosa-cvrexport-plusByron-2.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/2-alamosa-cvrexport-plusByron-2.csv.sha256sum
+< ../CSVs/Demo1/2-alamosa-cvrexport-plusByron-2.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -157,13 +157,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="3-arapahoe-Byron-3-plus-tied-irv.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/3-arapahoe-Byron-3-plus-tied-irv.csv
+< ../CSVs/Demo1/3-arapahoe-Byron-3-plus-tied-irv.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/3-arapahoe-Byron-3-plus-tied-irv.csv.sha256sum
+< ../CSVs/Demo1/3-arapahoe-Byron-3-plus-tied-irv.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -216,12 +216,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="4-archuleta-kempsey-plusByron-4.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/4-archuleta-kempsey-plusByron-4.csv
+< ../CSVs/Demo1/4-archuleta-kempsey-plusByron-4.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/Demo1/4-archuleta-kempsey-plusByron-4.csv.sha256sum
+< ../CSVs/Demo1/4-archuleta-kempsey-plusByron-4.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -273,12 +273,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-5.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-5.csv
+< ../CSVs/split-Byron/Byron-5.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-5.csv.sha256sum
+< ../CSVs/split-Byron/Byron-5.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -330,12 +330,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-6.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-6.csv
+< ../CSVs/split-Byron/Byron-6.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-6.csv.sha256sum
+< ../CSVs/split-Byron/Byron-6.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -387,12 +387,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-8.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-8.csv
+< ../CSVs/split-Byron/Byron-8.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-8.csv.sha256sum
+< ../CSVs/split-Byron/Byron-8.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -449,12 +449,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-9.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-9.csv
+< ../CSVs/split-Byron/Byron-9.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-9.csv.sha256sum
+< ../CSVs/split-Byron/Byron-9.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -511,12 +511,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-10.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-10.csv
+< ../CSVs/split-Byron/Byron-10.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-10.csv.sha256sum
+< ../CSVs/split-Byron/Byron-10.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -573,12 +573,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-11.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-11.csv
+< ../CSVs/split-Byron/Byron-11.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-11.csv.sha256sum
+< ../CSVs/split-Byron/Byron-11.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -635,12 +635,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-12.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-12.csv
+< ../CSVs/split-Byron/Byron-12.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-12.csv.sha256sum
+< ../CSVs/split-Byron/Byron-12.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -697,12 +697,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-13.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-13.csv
+< ../CSVs/split-Byron/Byron-13.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-13.csv.sha256sum
+< ../CSVs/split-Byron/Byron-13.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -759,12 +759,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-14.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-14.csv
+< ../CSVs/split-Byron/Byron-14.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-14.csv.sha256sum
+< ../CSVs/split-Byron/Byron-14.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -821,12 +821,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-15.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-15.csv
+< ../CSVs/split-Byron/Byron-15.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-15.csv.sha256sum
+< ../CSVs/split-Byron/Byron-15.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -883,12 +883,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-16.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-16.csv
+< ../CSVs/split-Byron/Byron-16.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-16.csv.sha256sum
+< ../CSVs/split-Byron/Byron-16.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -945,12 +945,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-17.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-17.csv
+< ../CSVs/split-Byron/Byron-17.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-17.csv.sha256sum
+< ../CSVs/split-Byron/Byron-17.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1007,12 +1007,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-18.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-18.csv
+< ../CSVs/split-Byron/Byron-18.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-18.csv.sha256sum
+< ../CSVs/split-Byron/Byron-18.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1069,12 +1069,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-19.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-19.csv
+< ../CSVs/split-Byron/Byron-19.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-19.csv.sha256sum
+< ../CSVs/split-Byron/Byron-19.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1131,12 +1131,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-20.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-20.csv
+< ../CSVs/split-Byron/Byron-20.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-20.csv.sha256sum
+< ../CSVs/split-Byron/Byron-20.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1193,12 +1193,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-21.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-21.csv
+< ../CSVs/split-Byron/Byron-21.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-21.csv.sha256sum
+< ../CSVs/split-Byron/Byron-21.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1255,12 +1255,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-22.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-22.csv
+< ../CSVs/split-Byron/Byron-22.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-22.csv.sha256sum
+< ../CSVs/split-Byron/Byron-22.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1317,12 +1317,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-23.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-23.csv
+< ../CSVs/split-Byron/Byron-23.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-23.csv.sha256sum
+< ../CSVs/split-Byron/Byron-23.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1379,12 +1379,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-24.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-24.csv
+< ../CSVs/split-Byron/Byron-24.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-24.csv.sha256sum
+< ../CSVs/split-Byron/Byron-24.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1441,12 +1441,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-25.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-25.csv
+< ../CSVs/split-Byron/Byron-25.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-25.csv.sha256sum
+< ../CSVs/split-Byron/Byron-25.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1503,12 +1503,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-26.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-26.csv
+< ../CSVs/split-Byron/Byron-26.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-26.csv.sha256sum
+< ../CSVs/split-Byron/Byron-26.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1565,12 +1565,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-27.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-27.csv
+< ../CSVs/split-Byron/Byron-27.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-27.csv.sha256sum
+< ../CSVs/split-Byron/Byron-27.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1627,12 +1627,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-28.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-28.csv
+< ../CSVs/split-Byron/Byron-28.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-28.csv.sha256sum
+< ../CSVs/split-Byron/Byron-28.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1689,12 +1689,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-29.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-29.csv
+< ../CSVs/split-Byron/Byron-29.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-29.csv.sha256sum
+< ../CSVs/split-Byron/Byron-29.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1751,12 +1751,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-30.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-30.csv
+< ../CSVs/split-Byron/Byron-30.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-30.csv.sha256sum
+< ../CSVs/split-Byron/Byron-30.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1813,12 +1813,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-31.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-31.csv
+< ../CSVs/split-Byron/Byron-31.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-31.csv.sha256sum
+< ../CSVs/split-Byron/Byron-31.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1875,12 +1875,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-32.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-32.csv
+< ../CSVs/split-Byron/Byron-32.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-32.csv.sha256sum
+< ../CSVs/split-Byron/Byron-32.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1937,12 +1937,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-33.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-33.csv
+< ../CSVs/split-Byron/Byron-33.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-33.csv.sha256sum
+< ../CSVs/split-Byron/Byron-33.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1999,12 +1999,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-34.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-34.csv
+< ../CSVs/split-Byron/Byron-34.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-34.csv.sha256sum
+< ../CSVs/split-Byron/Byron-34.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2061,12 +2061,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-35.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-35.csv
+< ../CSVs/split-Byron/Byron-35.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-35.csv.sha256sum
+< ../CSVs/split-Byron/Byron-35.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2123,12 +2123,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-36.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-36.csv
+< ../CSVs/split-Byron/Byron-36.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-36.csv.sha256sum
+< ../CSVs/split-Byron/Byron-36.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2185,12 +2185,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-37.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-37.csv
+< ../CSVs/split-Byron/Byron-37.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-37.csv.sha256sum
+< ../CSVs/split-Byron/Byron-37.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2247,12 +2247,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-38.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-38.csv
+< ../CSVs/split-Byron/Byron-38.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-38.csv.sha256sum
+< ../CSVs/split-Byron/Byron-38.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2309,12 +2309,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-39.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-39.csv
+< ../CSVs/split-Byron/Byron-39.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-39.csv.sha256sum
+< ../CSVs/split-Byron/Byron-39.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2371,12 +2371,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-40.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-40.csv
+< ../CSVs/split-Byron/Byron-40.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-40.csv.sha256sum
+< ../CSVs/split-Byron/Byron-40.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2433,12 +2433,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-41.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-41.csv
+< ../CSVs/split-Byron/Byron-41.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-41.csv.sha256sum
+< ../CSVs/split-Byron/Byron-41.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2495,12 +2495,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-42.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-42.csv
+< ../CSVs/split-Byron/Byron-42.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-42.csv.sha256sum
+< ../CSVs/split-Byron/Byron-42.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2557,12 +2557,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-43.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-43.csv
+< ../CSVs/split-Byron/Byron-43.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-43.csv.sha256sum
+< ../CSVs/split-Byron/Byron-43.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2619,12 +2619,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-44.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-44.csv
+< ../CSVs/split-Byron/Byron-44.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-44.csv.sha256sum
+< ../CSVs/split-Byron/Byron-44.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2681,12 +2681,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-45.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-45.csv
+< ../CSVs/split-Byron/Byron-45.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-45.csv.sha256sum
+< ../CSVs/split-Byron/Byron-45.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2743,12 +2743,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-46.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-46.csv
+< ../CSVs/split-Byron/Byron-46.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-46.csv.sha256sum
+< ../CSVs/split-Byron/Byron-46.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2805,12 +2805,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-47.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-47.csv
+< ../CSVs/split-Byron/Byron-47.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-47.csv.sha256sum
+< ../CSVs/split-Byron/Byron-47.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2867,12 +2867,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-48.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-48.csv
+< ../CSVs/split-Byron/Byron-48.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-48.csv.sha256sum
+< ../CSVs/split-Byron/Byron-48.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2929,12 +2929,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-49.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-49.csv
+< ../CSVs/split-Byron/Byron-49.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-49.csv.sha256sum
+< ../CSVs/split-Byron/Byron-49.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2991,12 +2991,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-50.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-50.csv
+< ../CSVs/split-Byron/Byron-50.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-50.csv.sha256sum
+< ../CSVs/split-Byron/Byron-50.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3053,12 +3053,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-51.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-51.csv
+< ../CSVs/split-Byron/Byron-51.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-51.csv.sha256sum
+< ../CSVs/split-Byron/Byron-51.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3115,12 +3115,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-52.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-52.csv
+< ../CSVs/split-Byron/Byron-52.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-52.csv.sha256sum
+< ../CSVs/split-Byron/Byron-52.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3177,12 +3177,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-53.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-53.csv
+< ../CSVs/split-Byron/Byron-53.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-53.csv.sha256sum
+< ../CSVs/split-Byron/Byron-53.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3239,12 +3239,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-54.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-54.csv
+< ../CSVs/split-Byron/Byron-54.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-54.csv.sha256sum
+< ../CSVs/split-Byron/Byron-54.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3301,12 +3301,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-55.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-55.csv
+< ../CSVs/split-Byron/Byron-55.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-55.csv.sha256sum
+< ../CSVs/split-Byron/Byron-55.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3363,12 +3363,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-56.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-56.csv
+< ../CSVs/split-Byron/Byron-56.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-56.csv.sha256sum
+< ../CSVs/split-Byron/Byron-56.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3425,12 +3425,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-57.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-57.csv
+< ../CSVs/split-Byron/Byron-57.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-57.csv.sha256sum
+< ../CSVs/split-Byron/Byron-57.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3487,12 +3487,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-58.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-58.csv
+< ../CSVs/split-Byron/Byron-58.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-58.csv.sha256sum
+< ../CSVs/split-Byron/Byron-58.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3549,12 +3549,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-59.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-59.csv
+< ../CSVs/split-Byron/Byron-59.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-59.csv.sha256sum
+< ../CSVs/split-Byron/Byron-59.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3611,12 +3611,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-60.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-60.csv
+< ../CSVs/split-Byron/Byron-60.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-60.csv.sha256sum
+< ../CSVs/split-Byron/Byron-60.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3673,12 +3673,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-61.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-61.csv
+< ../CSVs/split-Byron/Byron-61.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-61.csv.sha256sum
+< ../CSVs/split-Byron/Byron-61.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3735,12 +3735,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-62.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-62.csv
+< ../CSVs/split-Byron/Byron-62.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-62.csv.sha256sum
+< ../CSVs/split-Byron/Byron-62.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3797,12 +3797,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-63.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-63.csv
+< ../CSVs/split-Byron/Byron-63.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-63.csv.sha256sum
+< ../CSVs/split-Byron/Byron-63.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3859,12 +3859,12 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-64.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-64.csv
+< ../CSVs/split-Byron/Byron-64.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 
-< ../resources/CSVs/split-Byron/Byron-64.csv.sha256sum
+< ../CSVs/split-Byron/Byron-64.csv.sha256sum
 --TheBoundary--
 
 > {%

--- a/server/eclipse-project/src/test/resources/workflows/demo1_loadCVRs.http
+++ b/server/eclipse-project/src/test/resources/workflows/demo1_loadCVRs.http
@@ -10,7 +10,7 @@ Content-Type: application/json
   "password":""
 }
 > {%
-  import {authSanityCheck} from 'workflows/testScripts/testUtils';
+  import {authSanityCheck} from 'testScripts/testUtils';
   authSanityCheck("countyadmin1", 1, 'TRADITIONALLY_AUTHENTICATED');
 %}
 
@@ -24,7 +24,7 @@ Content-Type: application/json
 }
 
 > {%
-  import {authSanityCheck} from 'workflows/testScripts/testUtils';
+  import {authSanityCheck} from 'testScripts/testUtils';
   authSanityCheck("countyadmin1", 2, 'SECOND_FACTOR_AUTHENTICATED');
  %}
 

--- a/server/eclipse-project/src/test/resources/workflows/demo1_loadManifests.http
+++ b/server/eclipse-project/src/test/resources/workflows/demo1_loadManifests.http
@@ -30,13 +30,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="1-adams-plusByron-1-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/1-adams-plusByron-1-manifest.csv
+< ../CSVs/Demo1/1-adams-plusByron-1-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/1-adams-plusByron-1-manifest.csv.sha256sum
+< ../CSVs/Demo1/1-adams-plusByron-1-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -88,13 +88,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="2-alamosa-plusByron-2-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/2-alamosa-plusByron-2-manifest.csv
+< ../CSVs/Demo1/2-alamosa-plusByron-2-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/Demo1/2-alamosa-plusByron-2-manifest.csv.sha256sum
+< ../CSVs/Demo1/2-alamosa-plusByron-2-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -146,13 +146,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-3-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-3-manifest.csv
+< ../CSVs/split-Byron/Byron-3-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-3-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-3-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -204,13 +204,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Kempsey_Mayoral.manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/NewSouthWales21/Kempsey_Mayoral.manifest.csv
+< ../CSVs/NewSouthWales21/Kempsey_Mayoral.manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/NewSouthWales21/Kempsey_Mayoral.manifest.csv.sha256sum
+< ../CSVs/NewSouthWales21/Kempsey_Mayoral.manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -261,13 +261,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-5-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-5-manifest.csv
+< ../CSVs/split-Byron/Byron-5-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-5-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-5-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -318,13 +318,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-6-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-6-manifest.csv
+< ../CSVs/split-Byron/Byron-6-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-6-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-6-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -375,13 +375,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-8-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-8-manifest.csv
+< ../CSVs/split-Byron/Byron-8-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-8-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-8-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -437,13 +437,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-9-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-9-manifest.csv
+< ../CSVs/split-Byron/Byron-9-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-9-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-9-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -499,13 +499,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-10-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-10-manifest.csv
+< ../CSVs/split-Byron/Byron-10-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-10-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-10-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -561,13 +561,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-11-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-11-manifest.csv
+< ../CSVs/split-Byron/Byron-11-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-11-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-11-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -623,13 +623,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-12-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-12-manifest.csv
+< ../CSVs/split-Byron/Byron-12-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-12-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-12-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -685,13 +685,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-13-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-13-manifest.csv
+< ../CSVs/split-Byron/Byron-13-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-13-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-13-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -747,13 +747,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-14-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-14-manifest.csv
+< ../CSVs/split-Byron/Byron-14-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-14-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-14-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -809,13 +809,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-15-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-15-manifest.csv
+< ../CSVs/split-Byron/Byron-15-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-15-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-15-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -871,13 +871,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-16-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-16-manifest.csv
+< ../CSVs/split-Byron/Byron-16-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-16-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-16-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -933,13 +933,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-17-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-17-manifest.csv
+< ../CSVs/split-Byron/Byron-17-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-17-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-17-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -995,13 +995,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-18-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-18-manifest.csv
+< ../CSVs/split-Byron/Byron-18-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-18-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-18-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1057,13 +1057,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-19-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-19-manifest.csv
+< ../CSVs/split-Byron/Byron-19-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-19-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-19-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1119,13 +1119,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-20-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-20-manifest.csv
+< ../CSVs/split-Byron/Byron-20-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-20-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-20-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1181,13 +1181,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-21-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-21-manifest.csv
+< ../CSVs/split-Byron/Byron-21-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-21-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-21-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1243,13 +1243,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-22-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-22-manifest.csv
+< ../CSVs/split-Byron/Byron-22-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-22-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-22-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1305,13 +1305,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-23-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-23-manifest.csv
+< ../CSVs/split-Byron/Byron-23-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-23-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-23-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1367,13 +1367,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-24-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-24-manifest.csv
+< ../CSVs/split-Byron/Byron-24-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-24-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-24-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1429,13 +1429,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-25-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-25-manifest.csv
+< ../CSVs/split-Byron/Byron-25-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-25-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-25-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1491,13 +1491,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-26-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-26-manifest.csv
+< ../CSVs/split-Byron/Byron-26-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-26-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-26-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1553,13 +1553,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-27-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-27-manifest.csv
+< ../CSVs/split-Byron/Byron-27-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-27-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-27-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1615,13 +1615,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-28-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-28-manifest.csv
+< ../CSVs/split-Byron/Byron-28-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-28-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-28-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1677,13 +1677,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-29-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-29-manifest.csv
+< ../CSVs/split-Byron/Byron-29-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-29-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-29-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1739,13 +1739,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-30-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-30-manifest.csv
+< ../CSVs/split-Byron/Byron-30-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-30-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-30-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1801,13 +1801,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-31-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-31-manifest.csv
+< ../CSVs/split-Byron/Byron-31-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-31-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-31-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1863,13 +1863,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-32-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-32-manifest.csv
+< ../CSVs/split-Byron/Byron-32-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-32-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-32-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1925,13 +1925,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-33-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-33-manifest.csv
+< ../CSVs/split-Byron/Byron-33-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-33-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-33-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -1987,13 +1987,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-34-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-34-manifest.csv
+< ../CSVs/split-Byron/Byron-34-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-34-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-34-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2049,13 +2049,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-35-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-35-manifest.csv
+< ../CSVs/split-Byron/Byron-35-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-35-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-35-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2111,13 +2111,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-36-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-36-manifest.csv
+< ../CSVs/split-Byron/Byron-36-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-36-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-36-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2173,13 +2173,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-37-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-37-manifest.csv
+< ../CSVs/split-Byron/Byron-37-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-37-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-37-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2235,13 +2235,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-38-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-38-manifest.csv
+< ../CSVs/split-Byron/Byron-38-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-38-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-38-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2297,13 +2297,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-39-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-39-manifest.csv
+< ../CSVs/split-Byron/Byron-39-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-39-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-39-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2359,13 +2359,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-40-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-40-manifest.csv
+< ../CSVs/split-Byron/Byron-40-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-40-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-40-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2421,13 +2421,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-41-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-41-manifest.csv
+< ../CSVs/split-Byron/Byron-41-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-41-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-41-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2483,13 +2483,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-42-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-42-manifest.csv
+< ../CSVs/split-Byron/Byron-42-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-42-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-42-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2545,13 +2545,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-43-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-43-manifest.csv
+< ../CSVs/split-Byron/Byron-43-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-43-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-43-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2607,13 +2607,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-44-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-44-manifest.csv
+< ../CSVs/split-Byron/Byron-44-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-44-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-44-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2669,13 +2669,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-45-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-45-manifest.csv
+< ../CSVs/split-Byron/Byron-45-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-45-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-45-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2731,13 +2731,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-46-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-46-manifest.csv
+< ../CSVs/split-Byron/Byron-46-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-46-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-46-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2793,13 +2793,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-47-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-47-manifest.csv
+< ../CSVs/split-Byron/Byron-47-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-47-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-47-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2855,13 +2855,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-48-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-48-manifest.csv
+< ../CSVs/split-Byron/Byron-48-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-48-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-48-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2917,13 +2917,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-49-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-49-manifest.csv
+< ../CSVs/split-Byron/Byron-49-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-49-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-49-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -2979,13 +2979,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-50-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-50-manifest.csv
+< ../CSVs/split-Byron/Byron-50-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-50-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-50-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3041,13 +3041,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-51-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-51-manifest.csv
+< ../CSVs/split-Byron/Byron-51-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-51-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-51-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3103,13 +3103,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-52-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-52-manifest.csv
+< ../CSVs/split-Byron/Byron-52-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-52-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-52-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3165,13 +3165,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-53-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-53-manifest.csv
+< ../CSVs/split-Byron/Byron-53-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-53-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-53-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3227,13 +3227,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-54-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-54-manifest.csv
+< ../CSVs/split-Byron/Byron-54-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-54-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-54-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3289,13 +3289,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-55-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-55-manifest.csv
+< ../CSVs/split-Byron/Byron-55-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-55-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-55-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3351,13 +3351,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-56-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-56-manifest.csv
+< ../CSVs/split-Byron/Byron-56-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-56-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-56-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3413,13 +3413,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-57-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-57-manifest.csv
+< ../CSVs/split-Byron/Byron-57-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-57-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-57-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3475,13 +3475,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-58-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-58-manifest.csv
+< ../CSVs/split-Byron/Byron-58-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-58-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-58-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3537,13 +3537,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-59-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-59-manifest.csv
+< ../CSVs/split-Byron/Byron-59-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-59-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-59-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3599,13 +3599,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-60-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-60-manifest.csv
+< ../CSVs/split-Byron/Byron-60-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-60-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-60-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3661,13 +3661,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-61-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-61-manifest.csv
+< ../CSVs/split-Byron/Byron-61-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-61-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-61-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3723,13 +3723,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-62-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-62-manifest.csv
+< ../CSVs/split-Byron/Byron-62-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-62-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-62-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3785,13 +3785,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-63-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-63-manifest.csv
+< ../CSVs/split-Byron/Byron-63-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-63-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-63-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%
@@ -3847,13 +3847,13 @@ Content-Type: multipart/form-data; boundary=TheBoundary
 Content-Disposition: form-data; name="file"; filename="Byron-64-manifest.csv"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-64-manifest.csv
+< ../CSVs/split-Byron/Byron-64-manifest.csv
 
 --TheBoundary
 Content-Disposition: form-data; name="hash"
 Content-Type: text/csv
 
-< ../resources/CSVs/split-Byron/Byron-64-manifest.csv.sha256sum
+< ../CSVs/split-Byron/Byron-64-manifest.csv.sha256sum
 --TheBoundary--
 
 > {%

--- a/server/eclipse-project/src/test/resources/workflows/testScripts/testUtils.js
+++ b/server/eclipse-project/src/test/resources/workflows/testScripts/testUtils.js
@@ -32,14 +32,3 @@ export function getContestIDsWithCounties(jsonString) {
 
   return contests;
 }
-
-export class ContestWithIDs {
-  constructor(name,IDName) {
-    // The name of the contest, as it appears in the CSV
-    this.contestName = name
-    // The name we'll use to retrieve it
-    this.IDName = IDName
-    // A list of (contestID, countyID) pairs that this contest name corresponds to.
-    this.IDs = []
-  }
-}

--- a/server/eclipse-project/src/test/resources/workflows/testScripts/testUtils.js
+++ b/server/eclipse-project/src/test/resources/workflows/testScripts/testUtils.js
@@ -5,3 +5,41 @@ export function authSanityCheck(login, stage, statusExpected) {
   client.assert(authStatus === statusExpected, 'Stage ' + stage + 'auth failed.');
 })
 }
+
+// Names List is a list of contest names, ID-tag) pairs. We use the jsonData to store the
+// contestID of the requested contest name into a global variable, indexed by the requested ID-tag.
+// Returns a map from contest name to a list of (contestID, countyID) pairs.
+export function getContestIDsWithCounties(jsonString) {
+
+  const contests = new Map();
+  const jsonData = JSON.parse(jsonString);
+
+  console.log("JsonData = "+jsonData);
+  // Initialize a map, with a key for each ID-tag and an empty list as its value.
+  for(var i=0; i < jsonData.length ; i++) {
+
+    const contestName = (jsonData[i]['name']);
+    console.log("jsonData[i] = "+jsonData[i]);
+    console.log("Found contest "+contestName);
+    if(!contests.has(contestName)) {
+      // We haven't seen this contest name before - add it to the map with an empty list of
+      // contestID-counyID pairs.
+      contests.set(contestName, []);
+    }
+    contests.get(contestName).push([jsonData[i]['id'],jsonData[i]['county_id']]);
+    console.log("Adding contest"+contestName+", ID = "+jsonData[i]['id']+", countyID = "+jsonData[i]['county_id']);
+  }
+
+  return contests;
+}
+
+export class ContestWithIDs {
+  constructor(name,IDName) {
+    // The name of the contest, as it appears in the CSV
+    this.contestName = name
+    // The name we'll use to retrieve it
+    this.IDName = IDName
+    // A list of (contestID, countyID) pairs that this contest name corresponds to.
+    this.IDs = []
+  }
+}


### PR DESCRIPTION
Don't merge this yet - I'm just putting in the PR to make it easy to review.
It contains a very small change to the server (just adding a query option to the /contest endpoint so that it returns data even if manifests are absent), but some significant changes to the client.

There might be a much better way to achieve the client-side changes @charliecarlton.

I used the .http files in /src/test/resources/workflows to load a bunch of things in automatically and then run the client UI locally. This now does the correct thing on the demo 1 data, but hasn't been carefully tested yet.

It runs through audit definition, contest-name canonicalization, candidate-name canonicalization, assertion generation, and sample-size estimation, then gives the 'waiting for counties to upload contest data' error when it reaches the step of targeting contests. This seems good to me - we don't want it to progress past that point without manifests.

