### PR TITLE
Bumping GSON to most recent version

### DIFF
--- a/server/eclipse-project/pom.xml
+++ b/server/eclipse-project/pom.xml
@@ -216,7 +216,7 @@
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.8.1</version>
+			<version>2.12.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/endpoint/GenerateAssertionsTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/endpoint/GenerateAssertionsTests.java
@@ -313,9 +313,11 @@ public class GenerateAssertionsTests extends TestClassWithDatabase {
   /**
    * When raire sends an uninterpretable response, an appropriate error message appears.
    * This tests a response that is not valid json.
+   * The (?s) workaround is added because otherwise the regexp was failing to match, but tbh I'm not
+   * sure why that's necessary.
    */
   @Test(expectedExceptions = RuntimeException.class,
-      expectedExceptionsMessageRegExp = ".*Error interpreting Raire response for contest.*")
+      expectedExceptionsMessageRegExp = "(?s).*Error interpreting Raire response for contest.*")
   public void uninterpretableRaireResponseThrowsRuntimeException() {
     testUtils.log(LOGGER, "uninterpretableRaireResponseThrowsRuntimeException");
 
@@ -329,7 +331,7 @@ public class GenerateAssertionsTests extends TestClassWithDatabase {
    * This tests a response that is valid json, but not the json we were expecting.
    */
   @Test(expectedExceptions = RuntimeException.class,
-      expectedExceptionsMessageRegExp = ".*Error interpreting Raire response for contest.*")
+      expectedExceptionsMessageRegExp = "(?s).*Error interpreting Raire response for contest.*")
   public void unexpectedRaireResponseThrowsRuntimeException() {
     testUtils.log(LOGGER, "unexpectedRaireResponseThrowsRuntimeException");
 


### PR DESCRIPTION
This currently causes two tests to fail, I think due to slightly different data serialization methods in the new GSON? 

`unexpectedRaireResponseThrowsRuntimeException` fails with

```
org.testng.TestException: 
The exception was thrown with the wrong message: expected ".*Error interpreting Raire response for contest.*" but got "[generateAssertionsUpdateWinners] Error interpreting Raire response for contest  TinyExample1. java.lang.IllegalStateException: Expected BEGIN_OBJECT but was BEGIN_ARRAY at line 1 column 2 path $
See https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure"
```

And `uninterpretableRaireResponseThrowsRuntimeException` fails with:
```
org.testng.TestException: 
The exception was thrown with the wrong message: expected ".*Error interpreting Raire response for contest.*" but got "[generateAssertionsUpdateWinners] Error interpreting Raire response for contest  TinyExample1. java.lang.IllegalStateException: Expected BEGIN_OBJECT but was STRING at line 1 column 1 path $
See https://github.com/google/gson/blob/main/Troubleshooting.md#unexpected-json-structure"
```
