### PR TITLE
Update links to IRV regulations, and order of application of IRV rule…

### DIFF
--- a/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
+++ b/server/eclipse-project/src/main/java/au/org/democracydevelopers/corla/model/vote/IRVChoices.java
@@ -56,6 +56,8 @@ import java.util.stream.Collectors;
  * - getValidIntentAsOrderedList(): applies Colorado's IRV rules and returns the valid
  *   interpretation, as an ordered list of candidate names with the highest preference first. In
  *   particular, it applies Rule_26_7_3_Duplicates() before Rule_26_7_1_Overvotes() as required.
+ *   (See note in that function about skipped ranks - our implementation is slightly different but
+ *   equivalent to the implementation specified in the regulations.)
  */
 public class IRVChoices {
 
@@ -183,7 +185,10 @@ public class IRVChoices {
    * to produce a valid IRV vote, and returns that valid IRV vote as an ordered list of candidate
    * names, with the highest-preference candidate first.
    * This specifies that candidate duplicates (Rule 26.7.3) should be removed before overvotes
-   * (Rule 26.7.1).
+   * (Rule 26.7.1). Although the regulation specify that skipped preferences should be addressed
+   * first (Rule 26.7.2), we do them last in case skips have been introduced by the application of
+   * Rules 26.7.1 or 26.7.3. This would have to be done anyway, and it makes no difference whether
+   * it is also done at the beginning.
    * If the IRV vote is already valid, it will be returned as an ordered list of candidate names
    * in preference order (highest preference first).
    *
@@ -195,7 +200,7 @@ public class IRVChoices {
     LOGGER.debug(String.format("%s getting valid interpretation of vote %s.", prefix,
         choices.toString()));
 
-    List<String> valid = this.rule_26_7_2_Skips().rule_26_7_3_Duplicates().rule_26_7_1_Overvotes()
+    List<String> valid = this.rule_26_7_3_Duplicates().rule_26_7_1_Overvotes().rule_26_7_2_Skips()
         .choices.stream().map(c -> c.candidateName).collect(Collectors.toList());
     LOGGER.debug(String.format("%s valid interpretation is %s.", prefix, valid));
     return valid;

--- a/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
+++ b/server/eclipse-project/src/test/java/au/org/democracydevelopers/corla/model/vote/IRVChoicesTests.java
@@ -33,12 +33,9 @@ import static org.testng.Assert.*;
 /**
  * Tests for proper interpretation of IRV choices, including proper interpretation of invalid
  * choices involving repeated candidate names and repeated or skipped preferences.
- * The implementation follows the rules specified in Colorado's Guide to Voter Intent -
- * Determination of Voter Intent for Colorado Elections, 2023 addendum for Instant Runoff Voting
- * (IRV), available at
- * <a href="https://assets.bouldercounty.gov/wp-content/uploads/2023/11/Voter-Intent-Guide-IRV-Addendum-2023.pdf">...</a>
- * TODO This may be updated soon - updated ref to CDOS rather than Boulder when official CDOS
- * version becomes available.
+ * The implementation follows the rules specified in Colorado's
+ * <A HREF="https://www.sos.state.co.us/pubs/rule_making/CurrentRules/8CCR1505-1/Rule26.pdf">
+ *   Election Rules [8 CCR 1505-1] Rule 26</A>
  * Examples are taken directly from the Guide, with example numbers (if given) from there.
  */
 public class IRVChoicesTests {
@@ -58,7 +55,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER, "Example1OvervotesNoValidRankings");
 
     IRVChoices b = new IRVChoices("Candidate A(1),Candidate B(1),Candidate C(1),Candidate C(2),Candidate B(3)");
-    assertEquals(0, b.getValidIntentAsOrderedList().size());
+    assertEquals(b.getValidIntentAsOrderedList().size(), 0);
   }
 
   /**
@@ -136,7 +133,7 @@ public class IRVChoicesTests {
 
     IRVChoices b = new IRVChoices("");
     assertTrue(b.isValid());
-    assertEquals(0, b.getValidIntentAsOrderedList().size());
+    assertEquals(b.getValidIntentAsOrderedList().size(), 0);
   }
 
   /**
@@ -237,7 +234,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeOvervotesTest2");
 
     IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(2)");
-    assertEquals("Alice",b.getValidIntentAsOrderedList().get(0));
+    assertEquals(b.getValidIntentAsOrderedList().get(0), "Alice");
   }
 
   /**
@@ -250,7 +247,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeOvervotesTest3");
 
     IRVChoices b = new IRVChoices("Alice(1),Bob(2),Chuan(2),Diego(3)");
-    assertEquals("Alice",b.getValidIntentAsOrderedList().get(0));
+    assertEquals(b.getValidIntentAsOrderedList().get(0), "Alice");
   }
 
   /**
@@ -302,7 +299,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeSkipsTest2");
 
     IRVChoices b = new IRVChoices("Bob(2),Chuan(3)");
-    assertEquals(0,b.getValidIntentAsOrderedList().size());
+    assertEquals(b.getValidIntentAsOrderedList().size(), 0);
   }
 
   /**
@@ -328,7 +325,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeSkipsTest4");
 
     IRVChoices b = new IRVChoices("Alice(3),Bob(2),Chuan(4)");
-    assertEquals(0, b.getValidIntentAsOrderedList().size());
+    assertEquals(b.getValidIntentAsOrderedList().size(), 0);
   }
 
   /**
@@ -341,7 +338,7 @@ public class IRVChoicesTests {
     testUtils.log(LOGGER,"removeSkipsTest4");
 
     IRVChoices b = new IRVChoices("Alice(3)");
-    assertEquals(0, b.getValidIntentAsOrderedList().size());
+    assertEquals(b.getValidIntentAsOrderedList().size(), 0);
   }
 
   /**


### PR DESCRIPTION
…s. (This change does not change any outcomes.)

This was intended to be just an update of the comments linking to the regulations, which are the same as the regulations we used to write the code, but are now officially final and hence have a different url.

I decided to change the order of the rules to exactly match what the regulations say, specifically to move the removal of everything after a skipped preference (26.7.2) to the beginning rather than the end. This makes no difference to any outcomes, but I thought it was easier to do literally what the reg's say, than to explain to everyone that the apparently-different think we did was equivalent.