### PR TITLE
Check that we've got a sortable thing before we sort it.

### DIFF
--- a/client/src/reducer/root.ts
+++ b/client/src/reducer/root.ts
@@ -183,8 +183,8 @@ export default function root(state: AppState, action: Action.App) {
             return 0;
         };
 
-        // Put failed assertion generations at the front of the list
-        nextState.assertionGenerationStatuses = action.data.sort(compareStatus);
+        // Put failed assertion generations at the front of the list.
+        nextState.assertionGenerationStatuses = Array.isArray(action.data) ? action.data.sort(compareStatus) : [];
 
         nextState.generatingAssertions = false;
         nextState.assertionsGenerated = true;


### PR DESCRIPTION
Actually this turned out to not be an issue with null data, but rather with data that wasn't a list/array and therefore couldn't be sorted. Now fixed.